### PR TITLE
Add Pixie multi-tenant/-Org deployment helpers

### DIFF
--- a/src/api/python/requirements.bazel.txt
+++ b/src/api/python/requirements.bazel.txt
@@ -8,6 +8,10 @@ authlib==1.1.0 \
     --hash=sha256:0a270c91409fc2b7b0fbee6996e09f2ee3187358762111a9a4225c874b94e891 \
     --hash=sha256:be4b6a1dea51122336c210a6945b27a105b9ac572baffd15b07bcff4376c1523
     # via -r requirements.bazel.txt
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+    # via requests
 cffi==1.15.1 \
     --hash=sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5 \
     --hash=sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef \
@@ -74,6 +78,10 @@ cffi==1.15.1 \
     --hash=sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01 \
     --hash=sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0
     # via cryptography
+charset-normalizer==2.0.12 \
+    --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
+    --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
+    # via requests
 cryptography==38.0.4 \
     --hash=sha256:0e70da4bdff7601b0ef48e6348339e490ebfb0cbe638e083c9c41fb49f00c8bd \
     --hash=sha256:10652dd7282de17990b88679cb82f832752c4e8237f0c714be518044269415db \
@@ -102,6 +110,10 @@ cryptography==38.0.4 \
     --hash=sha256:ca57eb3ddaccd1112c18fc80abe41db443cc2e9dcb1917078e02dfa010a4f353 \
     --hash=sha256:ce127dd0a6a0811c251a6cddd014d292728484e530d80e872ad9806cfb1c5b3c
     # via authlib
+ddt==1.1.0 \
+    --hash=sha256:1ab0d77e5ecfae9a2b4244dd8079d8e248a69eae0260238516c260ac5e2bd007 \
+    --hash=sha256:5e08112c24279e458e0e5a9d8854eb0f15a00427a116d6728efaa3c8ac9fb221
+    # via -r requirements.bazel.txt
 gogo-python==0.0.1 \
     --hash=sha256:55300f8c7f3645a267a391cb439f89f15d21aa58e3a07653353923f9f6a3627b \
     --hash=sha256:6f68d3aa598ee2ca4d3bb44b8afa2d4ef4a3198d6f5ae3824f38fbca2c6653ed
@@ -204,6 +216,10 @@ grpcio-tools==1.47.0 \
     --hash=sha256:f64b5378484be1d6ce59311f86174be29c8ff98d8d90f589e1c56d5acae67d3c \
     --hash=sha256:fb44ae747fd299b6513420cb6ead50491dc3691d17da48f28fcc5ebf07f47741
     # via -r requirements.bazel.txt
+idna==3.4 \
+    --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
+    --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+    # via requests
 protobuf==3.20.3 \
     --hash=sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7 \
     --hash=sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c \
@@ -234,10 +250,18 @@ pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
     # via cffi
+requests==2.27.1 \
+    --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
+    --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
+    # via -r requirements.bazel.txt
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via grpcio
+urllib3==1.26.14 \
+    --hash=sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72 \
+    --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
+    # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==65.6.3 \

--- a/src/api/python/requirements.txt
+++ b/src/api/python/requirements.txt
@@ -1,5 +1,7 @@
 Authlib==1.1.0
+ddt==1.1.0
 gogo-python==0.0.1
 grpcio==1.47.0
 grpcio-tools==1.47.0
 protobuf==3.20.3
+requests==2.27.1

--- a/src/api/python/self_hosted_registration/BUILD.bazel
+++ b/src/api/python/self_hosted_registration/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@vizier_api_python_deps//:requirements.bzl", "requirement")
+
+py_library(
+    name = "self_hosted_registration_library",
+    srcs = [
+        "__init__.py",
+        "cli.py",
+        "registration.py",
+    ],
+    srcs_version = "PY3",
+    visibility = ["//src/api/python:__subpackages__"],
+    deps = [
+        requirement("requests"),
+    ],
+)

--- a/src/api/python/self_hosted_registration/__init__.py
+++ b/src/api/python/self_hosted_registration/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class Error(Exception):
+    """Base-class for exceptions in this module"""

--- a/src/api/python/self_hosted_registration/cli.py
+++ b/src/api/python/self_hosted_registration/cli.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+r"""
+Pixie registration CLI
+
+This module provides a script for onboarding Pixie Orgs and generating deployment and
+API keys for self-hosted Pixie cloud installations. This serves as preliminary step to
+Pixie Org deployment and bootstraps usage of the (more advanced) Pixie API client using
+gRPC/protobufs.
+
+Example for registering a new Pixie Org:
+
+    $ self_hosted_registration/cli.py \
+            --verbose \
+            --insecure \
+            --pixie-url 'https://work.dev.withpixie.dev' \
+            --hydra-user-url https://work.dev.withpixie.dev/oauth/hydra \
+        register-pixie-org \
+            --pixie-org my_test_org
+
+    Pixie Org created: my_test_org
+    OAuth client-secret: <oauth-client-secret>
+    Administrator identity ID: <administrator-identity-id>
+    Administrator username: admin@my_test_org
+    Administrator password: <administrator-password>
+    API key ID: <api-key-id>
+    API key secret: <api-key-secret>
+
+Example for registering a new Pixie Org:
+
+    $ self_hosted_registration/cli.py \
+            --verbose \
+            --insecure \
+            --pixie-url 'https://work.dev.withpixie.dev' \
+            --hydra-user-url https://work.dev.withpixie.dev/oauth/hydra \
+        add-deployment-key \
+            --identity-id <administrator-identity-id>
+    Please provide client-secret: <oauth-client-secret>
+
+    Deployment-key ID: <deployment-key-id>
+    Deployment-key secret: <deployment-key-secret>
+
+NOTE: In all examples, we assume the parent directory of this script has been added to
+the PYTHONPATH.
+
+For a list of available commands, use
+
+    $ self_hosted_registration/cli.py --help
+
+For a list of available options for each command, use
+
+    $ self_hosted_registration/cli.py <command> --help
+"""
+
+import argparse
+import enum
+import getpass
+import http
+import http.client
+import json
+import logging
+import random
+import string
+import sys
+import typing
+import yaml
+
+import self_hosted_registration
+from self_hosted_registration import registration
+
+
+class Error(self_hosted_registration.Error):
+    """Base-class for exceptions in this module"""
+
+
+class EnumWithFromValue(enum.Enum):
+    """Wrapper around `enum.Enum` that supports `from_value()`"""
+
+    def __str__(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_value(cls, value: str):
+        """
+        Look up enum element by its value
+
+        NOTE: Needed for usage in `argparse`
+
+        :param value: The value of the component
+        :return: An enum element
+        :rtype: cls
+        :raise: ValueError
+        """
+        for element in cls:
+            if element.value == value:
+                return element
+        raise ValueError(value)
+
+
+@enum.unique
+class ScriptCommand(EnumWithFromValue):
+    """The "commands" supported by this script"""
+
+    REGISTER_PIXIE_ORG = "register-pixie-org"
+    DELETE_IDENTITY = "delete-identity"
+    ADD_DEPLOYMENT_KEY = "add-deployment-key"
+
+
+@enum.unique
+class ScriptOutputFormat(EnumWithFromValue):
+    """The "output formats" supported by this script"""
+
+    TEXT = "text"
+    YAML = "yaml"
+    JSON = "json"
+
+
+def get_random_password(
+    password_chars: str = string.ascii_letters + string.digits,
+    password_length: int = 32,
+) -> str:
+    """
+    Get a random password
+
+    :param password_chars: String from which to choose password characters
+    :param password_length: Length of the password
+    :return: Password string
+    """
+    return "".join(random.choices(password_chars, k=password_length))
+
+
+def get_password_from_file_or_stdin(
+    filename: typing.Optional[str],
+    password_description: str,
+    strip_password: bool = True,
+) -> str:
+    """
+    Get a password from file
+
+    :param filename: File to read; if `None`, read from stdin
+    :param password_description: Description of the password we are reading
+    :param strip_password: If `True`, remove leading and trailing whitespaces from the password.
+        Useful for passwords from file containing newlines
+    :return: Password string
+    :raise Error: Reading failed
+    """
+    if filename is None:
+        secret_value = getpass.getpass(
+            prompt=f"Please provide {password_description}: "
+        )
+    else:
+        try:
+            with open(filename, mode="rt", encoding="UTF-8") as secret_file:
+                secret_value = secret_file.read()
+        except IOError as err:
+            raise Error(
+                f"Reading {password_description} from {filename} failed: {err}"
+            ) from err
+    if strip_password:
+        secret_value = secret_value.strip()
+    if not secret_value:
+        raise Error(f"Invalid {password_description}: cannot be empty")
+    return secret_value
+
+
+def parse_cli() -> typing.Tuple[argparse.ArgumentParser, argparse.Namespace]:
+    """Helper to get the CLI parser"""
+    parser = argparse.ArgumentParser(
+        usage="""
+===============================================================================
+"""
+        + __doc__.strip()
+        + """
+
+===============================================================================
+
+USAGE: %(prog)s [options]
+
+"""
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Enable verbose logging (use multiple times for even more verbose logging). NOTE: "
+        "Very very verbose (-vvv) logging enables emitting debug logs of the API responses, which "
+        "contains session tokens. Very very very verbose (-vvvv) logging will emit raw HTTP "
+        "requests and will contain all contents, including passwords. Do NOT use in production "
+        "environments if outputs are logged",
+    )
+    for api in registration.ApiRequestHelper.KNOWN_APIS:
+        api_name = api.name.value
+
+        def flag_name(option):
+            # pylint: disable=cell-var-from-loop
+            return f"--{api_name.lower().replace(' ', '-')}-{option}"
+
+        parser.add_argument(
+            flag_name("url"),
+            default=api.default_base_url,
+            help=f"Base path to the {api_name} API (default: %(default)s).",
+        )
+        flag_name_insecure = flag_name("insecure")
+        parser.add_argument(
+            flag_name_insecure,
+            action="store_true",
+            help=f"Do not validate SSL connections to {api_name}.",
+        )
+        parser.add_argument(
+            flag_name("verify"),
+            required=False,
+            help="Optional path to certificate bundle for validating SSL connections "
+            + f"to {api_name}. Ignored if using {flag_name_insecure}",
+        )
+    # add a "global insecure" flag just for convenience of use
+    parser.add_argument(
+        "-k",
+        "--insecure",
+        action="store_true",
+        help="Do not validate SSL connections to any API.",
+    )
+    parser.add_argument(
+        "--output",
+        type=ScriptOutputFormat,
+        default=ScriptOutputFormat.TEXT.value,
+        help="Format of the output to produce (choose from "
+        f"{', '.join(str(output.value) for output in ScriptOutputFormat)}; default: %(default)s).",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="command",
+        # NOTE: `add_subparsers(required=True)` was added only in Python 3.7, and we
+        # don't want to break older python versions
+        # required=True,
+    )
+
+    register_org_parser = subparsers.add_parser(
+        ScriptCommand.REGISTER_PIXIE_ORG.value, help="Register a new Pixie Org."
+    )
+    register_org_parser.add_argument(
+        "--pixie-org",
+        required=True,
+        type=str,
+        help="Name of the Pixie Org to register (must match "
+        f"{registration.PixieRegistrationApiClient.PIXIE_ORG_NAME_REGEXP.pattern}).",
+    )
+    register_org_parser.add_argument(
+        "--client-secret",
+        type=str,
+        default=None,
+        # NOTE: We don't provide a "--from-file" to double-down on encouraging the user to not
+        # specify the secret and let the script auto-generate it
+        help="Optional client secret for creating the Machine-To-Machine OAuth client. If not "
+        "provided, a random secret is generated. This secret must be stored securely for later "
+        "automation, do not give to users. NOTE: It is strongly discouraged to specify a "
+        "secret; instead, let the script auto-generate a strong secret.",
+    )
+    register_org_parser.add_argument(
+        "--admin-email-address",
+        type=str,
+        default=None,
+        help="Optional email address to use for the administrative account. If not provided, "
+        "it default to admin@<pixie-org>.",
+    )
+    register_org_parser.add_argument(
+        "--admin-password",
+        type=str,
+        default=None,
+        # NOTE: We don't provide a "--from-file" to double-down on encouraging the user to not
+        # specify the password and let the script auto-generate it
+        help="Optional password for the administrative account. If not provided, a random "
+        "password is generated. NOTE: It is strongly discouraged to specify a password; instead, "
+        "let the script auto-generate a strong password.",
+    )
+    register_org_parser.add_argument(
+        "--skip-pixie-api-key-creation",
+        dest="create_pixie_api_key",
+        action="store_false",
+        help="Skip creation of the Pixie API key.",
+    )
+
+    delete_identity_parser = subparsers.add_parser(
+        ScriptCommand.DELETE_IDENTITY.value,
+        help="Delete an identity. NOTE: This will not delete the Pixie Org, as this is "
+        "currently not exposed via APIs.",
+    )
+    delete_identity_parser.add_argument(
+        "--identity-id",
+        type=str,
+        required=True,
+        help="ID of the administrative account of the Pixie Org to delete.",
+    )
+
+    add_deployment_parser = subparsers.add_parser(
+        ScriptCommand.ADD_DEPLOYMENT_KEY.value,
+        help="Add a new Vizier deployment-key.",
+    )
+    add_deployment_parser.add_argument(
+        "--identity-id",
+        type=str,
+        required=True,
+        help="ID of the administrative account of the Pixie Org to use.",
+    )
+    add_deployment_parser.add_argument(
+        "--client-secret",
+        type=str,
+        default=None,
+        help="Use this client secret for authenticating the Machine-To-Machine OAuth "
+        "client (instead of reading from file or stdin).",
+    )
+    add_deployment_parser.add_argument(
+        "--client-secret-from-file",
+        type=str,
+        default="-",
+        help="Read the client secret for authenticating the Machine-To-Machine OAuth client from "
+        'this file; use "-" to read from stdin.',
+    )
+    args = parser.parse_args()
+
+    if not args.command:  # see comment above - we don't want to mark it as required
+        choices = ",".join(str(command) for command in ScriptCommand)
+        parser.error(f"Need type of command to run. Choose from {choices}")
+    # seems we cannot assign an enum type for sub-parsers, so we have to restore type-safety here
+    args.command = ScriptCommand.from_value(args.command)
+
+    # propagate the "global insecure" flag so we don't have to deal with it all over the place
+    if args.insecure:
+        for api in registration.ApiRequestHelper.KNOWN_APIS:
+            vars(args)[api.get_option_name("insecure")] = True
+
+    if args.command == ScriptCommand.REGISTER_PIXIE_ORG:
+        if not registration.PixieRegistrationApiClient.PIXIE_ORG_NAME_REGEXP.match(
+            args.pixie_org
+        ):
+            parser.error(f"Invalid Pixie Org: {args.pixie_org}")
+
+        if not args.client_secret:
+            args.client_secret = get_random_password()
+
+        if not args.admin_email_address:
+            args.admin_email_address = f"admin@{args.pixie_org}"
+
+        if not args.admin_password:
+            args.admin_password = get_random_password()
+
+    if args.command == ScriptCommand.ADD_DEPLOYMENT_KEY:
+        if not args.client_secret:
+            try:
+                args.client_secret = get_password_from_file_or_stdin(
+                    filename=None
+                    if args.client_secret_from_file == "-"
+                    else args.client_secret_from_file,
+                    password_description="client-secret",
+                )
+            except Error as err:
+                parser.error(err)
+
+    return parser, args
+
+
+def do_register_org(
+    pixie_org: str,
+    client_secret: str,
+    admin_email_address: str,
+    admin_password: str,
+    identity_admin_api_client: registration.IdentityAdminApiClient,
+    oauth_api_client: registration.OAuthApiClient,
+    pixie_api_client: registration.PixieRegistrationApiClient,
+    create_pixie_api_key: bool = True,
+    output_format: ScriptOutputFormat = ScriptOutputFormat.TEXT,
+) -> None:
+    """
+    Do "register-pixie-org" workflow
+
+    The Pixie Org registration work-flow does the following steps:
+    - create a new identity in Kratos for authentication (using email+password)
+    - create a new OAuth client in Hydra for authenticating the newly created identity. The
+      ID of the Kratos identity is used to identify this client
+    - create a Pixie Org, linked to the created identity, and initialize Pixie Org settings
+
+    :param pixie_org: Name of the Pixie Org to create
+    :param client_secret: Client secret for authenticating the Machine-To-Machine OAuth client
+    :param admin_email_address: Email address of the administrative user
+    :param admin_password: Administrative user password
+    :param identity_admin_api_client: API client for the identity APIs
+    :param oauth_api_client: API client for the oAuth API
+    :param PixieRegistrationApiClient: API client for the Pixie API
+    :param create_pixie_api_key: If `True`, create a default Pixie API key
+    :param output_format: Format output to use
+    """
+    logger = logging.getLogger("do_register_org")
+
+    logger.info("Creating identity: %s", admin_email_address)
+    identity_id = identity_admin_api_client.create_identity(
+        client_secret=client_secret,
+        email_address=admin_email_address,
+        password=admin_password,
+    )
+    logger.debug("Authenticating identity: %s", identity_id)
+    access_token = oauth_api_client.get_access_token(
+        username=identity_id,
+        password=client_secret,
+    )
+    logger.info("Performing Pixie Org signup: %s", pixie_org)
+    pixie_api_client.signup(
+        org_name=pixie_org,
+        access_token=access_token,
+    )
+
+    logger.debug("Performing Pixie API login")
+    pixie_api_client.login(access_token=access_token)
+    logger.info("Configuring Pixie Org settings: make user approvals a requirement")
+    pixie_api_client.configure_org_settings(enable_user_approvals=True)
+    logger.info("Configuring Pixie user settings: opt-out of UI analytics")
+    pixie_api_client.configure_user_settings(enable_analytics=False)
+
+    api_key_id, api_key_secret = None, None
+    if create_pixie_api_key:
+        logger.info("Creating Pixie API key")
+        api_key_id, api_key_secret = pixie_api_client.create_api_key()
+
+    logger.info("Pixie registration successful")
+    if output_format == ScriptOutputFormat.TEXT:
+        print(f"Pixie Org created: {pixie_org}")
+        print(f"OAuth client-secret: {client_secret}")
+        print(f"Administrator identity ID: {identity_id}")
+        print(f"Administrator username: {admin_email_address}")
+        print(f"Administrator password: {admin_password}")
+        if create_pixie_api_key:
+            print(f"API key ID: {api_key_id}")
+            print(f"API key secret: {api_key_secret}")
+    else:
+        output = {
+            "pixie_org": {
+                "name": pixie_org,
+            },
+            "admin_account": {
+                "id": identity_id,
+                "client_secret": client_secret,
+                "email_address": admin_email_address,
+                "password": admin_password,
+            },
+            "pixie_api": {
+                "temp_access_token": access_token,
+            },
+        }
+        if create_pixie_api_key:
+            output["pixie_api"]["api_key"] = {
+                "id": api_key_id,
+                "secret": api_key_secret,
+            }
+        if output_format == ScriptOutputFormat.JSON:
+            print(json.dumps(output, indent="    "))
+        elif output_format == ScriptOutputFormat.YAML:
+            print(yaml.safe_dump(output))
+
+
+def do_delete_identity(
+    identity_id: str,
+    identity_admin_api_client: registration.IdentityAdminApiClient,
+    output_format: ScriptOutputFormat = ScriptOutputFormat.TEXT,
+) -> None:
+    """
+    Do "delete-identity" workflow
+
+    :param identity_id: ID of the administrative user identity to delete
+    :param identity_admin_api_client: API client for the identity APIs
+    :param output_format: Format output to use
+    """
+    logger = logging.getLogger("do_delete_identity")
+
+    logger.info("Deleting identity: %s", identity_id)
+    # NOTE: Pixie has no API for doing this deletion, so this may cause issues later if the
+    # Pixie Org already exists
+    deleted = identity_admin_api_client.delete_identity(
+        identity_id=identity_id,
+    )
+    if deleted:
+        logger.info("Identity deletion successful")
+    else:
+        logger.info("Identity deletion skipped: identity not found")
+
+    if output_format == ScriptOutputFormat.TEXT:
+        print(f"Identity {'' if deleted else 'not '}deleted")
+    else:
+        output = {"deleted": deleted}
+        if output_format == ScriptOutputFormat.JSON:
+            print(json.dumps(output, indent="    "))
+        elif output_format == ScriptOutputFormat.YAML:
+            print(yaml.safe_dump(output))
+
+
+def do_add_deployment(
+    identity_id: str,
+    client_secret: str,
+    oauth_api_client: registration.OAuthApiClient,
+    pixie_api_client: registration.PixieRegistrationApiClient,
+    output_format: ScriptOutputFormat = ScriptOutputFormat.TEXT,
+) -> None:
+    """
+    Do "add-deployment" workflow
+
+    :param identity_id: ID of the administrative user identity
+    :param client_secret: Client secret for authenticating the Machine-To-Machine OAuth client
+    :param oauth_api_client: API client for the oAuth API
+    :param PixieRegistrationApiClient: API client for the Pixie API
+    :param output_format: Format output to use
+    """
+    logger = logging.getLogger("do_add_deployment")
+
+    logger.debug("Authenticating identity: %s", identity_id)
+    access_token = oauth_api_client.get_access_token(
+        username=identity_id,
+        password=client_secret,
+    )
+
+    logger.debug("Performing Pixie API login")
+    pixie_api_client.login(access_token=access_token)
+
+    logger.debug("Creating Pixie deployment-key")
+    (
+        deployment_key_id,
+        deployment_key_secret,
+    ) = pixie_api_client.create_deployment_key()
+    logger.debug("Created Pixie deployment-key: %s", deployment_key_id)
+    if output_format == ScriptOutputFormat.TEXT:
+        print(f"Deployment-key ID: {deployment_key_id}")
+        print(f"Deployment-key secret: {deployment_key_secret}")
+    else:
+        output = {
+            "deployment_key_id": deployment_key_id,
+            "deployment_key_secret": deployment_key_secret,
+        }
+        if output_format == ScriptOutputFormat.JSON:
+            print(json.dumps(output, indent="    "))
+        elif output_format == ScriptOutputFormat.YAML:
+            print(yaml.safe_dump(output))
+
+
+def main():
+    """Script entrypoint"""
+    _parser, args = parse_cli()
+    logging.basicConfig(
+        level=logging.DEBUG
+        if args.verbose > 1
+        else logging.INFO
+        if args.verbose
+        else logging.WARNING
+    )
+    logger = logging.getLogger("main")
+
+    if args.verbose > 3:  # enable tracing in requests in very very very verbose mode
+        http.client.HTTPConnection.debuglevel = 1
+
+    def get_identity_admin_api_client():
+        return registration.IdentityAdminApiClient(
+            kratos_api_client=registration.ApiRequestHelper.factory_by_known_api_name_from_cli(
+                api_name=registration.KnownApiName.KRATOS_ADMIN, args=args
+            ),
+            hydra_api_client=registration.ApiRequestHelper.factory_by_known_api_name_from_cli(
+                api_name=registration.KnownApiName.HYDRA_ADMIN, args=args
+            ),
+        )
+
+    def get_oauth_api_client():
+        return registration.OAuthApiClient(
+            api_client=registration.ApiRequestHelper.factory_by_known_api_name_from_cli(
+                api_name=registration.KnownApiName.HYDRA_USER, args=args
+            ),
+        )
+
+    def get_pixie_api_client():
+        return registration.PixieRegistrationApiClient(
+            api_client=registration.ApiRequestHelper.factory_by_known_api_name_from_cli(
+                api_name=registration.KnownApiName.PIXIE, args=args
+            ),
+        )
+
+    try:
+        if args.command == ScriptCommand.REGISTER_PIXIE_ORG:
+            do_register_org(
+                pixie_org=args.pixie_org,
+                client_secret=args.client_secret,
+                admin_email_address=args.admin_email_address,
+                admin_password=args.admin_password,
+                identity_admin_api_client=get_identity_admin_api_client(),
+                oauth_api_client=get_oauth_api_client(),
+                pixie_api_client=get_pixie_api_client(),
+                create_pixie_api_key=args.create_pixie_api_key,
+                output_format=args.output,
+            )
+        elif args.command == ScriptCommand.DELETE_IDENTITY:
+            do_delete_identity(
+                identity_id=args.identity_id,
+                identity_admin_api_client=get_identity_admin_api_client(),
+                output_format=args.output,
+            )
+        elif args.command == ScriptCommand.ADD_DEPLOYMENT_KEY:
+            do_add_deployment(
+                identity_id=args.identity_id,
+                client_secret=args.client_secret,
+                oauth_api_client=get_oauth_api_client(),
+                pixie_api_client=get_pixie_api_client(),
+                output_format=args.output,
+            )
+    except self_hosted_registration.Error as err:
+        logger.error("Invocation failed: %s", err)
+        if args.verbose > 3:
+            raise
+    except Exception as err:
+        logger.error("Unexpected error while processing request: %s", err)
+        raise
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/python/self_hosted_registration/registration.py
+++ b/src/api/python/self_hosted_registration/registration.py
@@ -1,0 +1,1154 @@
+#!/usr/bin/env python3
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pixie registration helper code
+#
+# This module provides helper classes for onboarding Pixie Orgs and generating deployment and
+# API keys. This serves as preliminary step to Org deployment and bootstraps usage of the (more
+# advanced) Pixie API client using gRPC/protobufs.
+#
+# Pixie uses the Ory system for identity management (a combination of the Kratos and Hydra APIs)
+# which this script deals with. It allows creating an Ory identity that can be used to authenticate
+# to the Pixie APIs and bootstrap the Pixie Org deployment.
+#
+# NOTE: Pixie uses the OAuth workflow for logins to obtain an `access_token`, which can then be
+# used to obtain an API token for interacting with the actual Pixie API. Internally it uses
+# Kratos (see https://www.ory.sh/docs/kratos/reference/api) for Identity management and
+# Hydra (see https://www.ory.sh/docs/hydra/reference/api) for the actual OAuth2 workflow
+# handling.
+
+import argparse
+import enum
+import http
+import http.client
+import logging
+import os
+import pprint
+import re
+import typing
+import urllib.parse
+
+import requests
+
+import self_hosted_registration
+
+
+# Pylint has a point, but we want to keep this module in a single file, as we are sharing it with
+# the OSS community
+#
+# pylint: disable=too-many-lines
+
+
+class Error(self_hosted_registration.Error):
+    """Base-class for exceptions in this module"""
+
+
+class ApiError(Error):
+    """Class for handling API request errors"""
+
+
+@enum.unique
+class KnownApiName(enum.Enum):
+    """Listing of known APIs"""
+
+    PIXIE = "Pixie"
+    KRATOS_ADMIN = "Kratos Admin"
+    HYDRA_ADMIN = "Hydra Admin"
+    HYDRA_USER = "Hydra User"
+
+
+class KnownApi(typing.NamedTuple):
+    """Helper for declaring known APIs"""
+
+    name: KnownApiName
+    default_base_url: str
+
+    def get_option_name(self, name: str) -> str:
+        """
+        Helper to get a standardized name for the given option specific to this API
+
+        :param name: Name of the option
+        :return: The <api>_<name> name for the given option for this API
+        """
+        return f"{self.name.value.lower().replace(' ', '_')}_{name}"
+
+
+class ApiRequestHelper:
+    """
+    Class for issuing API requests
+
+    NOTE: This is merely a thin wrapper around `requests` to reduce code-duplication
+    """
+
+    KNOWN_APIS = (
+        KnownApi(
+            name=KnownApiName.KRATOS_ADMIN,
+            # NOTE: This service/URL is not exposed in k8s ingress (rightfully so!). To access it,
+            # the user must run this code within the k8s cluster or tunnel to the service IP
+            default_base_url="https://kratos.plc.svc:4434",
+        ),
+        KnownApi(
+            name=KnownApiName.HYDRA_ADMIN,
+            # NOTE: This service/URL is not exposed in k8s ingress (rightfully so!). To access it,
+            # the user must run this code within the k8s cluster or tunnel to the service IP
+            default_base_url="https://hydra.plc.svc:4445",
+        ),
+        KnownApi(
+            name=KnownApiName.HYDRA_USER,
+            # NOTE: We use the URL exposed via k8s ingress. This API is also exposed internally
+            # using the following internal service name:
+            #
+            #     default_base_url="https://hydra.plc.svc:4444",
+            #
+            default_base_url="https://work.dev.withpixie.dev/oauth/hydra",
+        ),
+        KnownApi(
+            name=KnownApiName.PIXIE,
+            # NOTE: We must use the hostname chosen for the Pixie cloud that is exposed via
+            # the k8s ingress (rather than the internal service cloud-proxy-service.plc.svc),
+            # because using the service does not work and results in HTTP-404s
+            default_base_url="https://work.dev.withpixie.dev",
+        ),
+    )
+
+    @staticmethod
+    def factory_from_cli(
+        api: KnownApi,
+        args: argparse.Namespace,
+    ) -> "ApiRequestHelper":
+        """
+        Factory method for instantiating a client from CLI arguments
+
+        :param api: API to instantiate
+        :param args: CLI args
+        :return: API client
+        """
+
+        def arg_value(name: str) -> typing.Any:
+            return vars(args)[api.get_option_name(name=name)]
+
+        return ApiRequestHelper(
+            api_base_path=typing.cast(str, arg_value(name="url")),
+            verify=False
+            if typing.cast(bool, arg_value(name="insecure"))
+            else arg_value(name="verify"),
+            debug_responses=args.verbose > 2,
+            trace_json_responses=args.verbose > 2,
+        )
+
+    @classmethod
+    def factory_by_known_api_name_from_cli(
+        cls,
+        api_name: KnownApiName,
+        args: argparse.Namespace,
+    ) -> "ApiRequestHelper":
+        """
+        Factory method for instantiating a client from CLI arguments for "known APIs"
+
+        :param api_name: Name of the known API to instantiate
+        :param args: CLI args
+        :return: API client
+        :raise Error: Unknown API
+        """
+        for api in cls.KNOWN_APIS:
+            if api.name == api_name:
+                return cls.factory_from_cli(api=api, args=args)
+        raise Error(f"Unknown API {api_name}")
+
+    @staticmethod
+    def factory_from_env(
+        api: KnownApi,
+        env_variables_prefix: str = "",
+    ) -> "ApiRequestHelper":
+        """
+        Factory method for instantiating a client from environment data
+
+        :param api: API to instantiate
+        :param env_variables_prefix: Prefix for the read environment variables
+        :return: API client
+        :raise Error: Unknown API or invalid/incomplete environment
+        """
+
+        def env_value(
+            name: str,
+            value_type: type,
+            default_value: typing.Any = None,
+            return_default_value: bool = False,
+        ) -> typing.Any:
+            full_option_name = (
+                f"{env_variables_prefix}{api.get_option_name(name=name)}"
+            ).upper()
+            try:
+                value = os.environ[full_option_name]
+            except KeyError as err:
+                if return_default_value:
+                    return default_value
+                raise Error(
+                    f"Cannot instantiate {api.name.value} from env: missing {full_option_name}"
+                ) from err
+            if value_type == str:
+                return value
+            if value_type == bool:
+                if value.lower() == "true":
+                    return True
+                if value.lower() == "false":
+                    return False
+                raise Error(
+                    f"Cannot instantiate {api.name.value} from env: invalid bool value {value} "
+                    f"for {full_option_name}"
+                )
+            assert False, f"Unsupported env-variable type {value_type.__name__}"
+
+        debug_responses = env_value(
+            name="DEBUG_RESPONSES",
+            value_type=bool,
+            default_value=False,
+            return_default_value=True,
+        )
+        return ApiRequestHelper(
+            api_base_path=env_value(name="url", value_type=str),
+            verify=False
+            if env_value(
+                name="insecure",
+                value_type=bool,
+                default_value=False,
+                return_default_value=True,
+            )
+            else env_value(name="verify", value_type=str, return_default_value=True),
+            debug_responses=debug_responses,
+            trace_json_responses=debug_responses,
+        )
+
+    @classmethod
+    def factory_by_known_api_name_from_env(
+        cls,
+        api_name: KnownApiName,
+        env_variables_prefix: str = "",
+    ) -> "ApiRequestHelper":
+        """
+        Factory method for instantiating a client from CLI arguments for "known APIs"
+
+        :param api_name: Name of the known API to instantiate
+        :param env_variables_prefix: Prefix for the read environment variables
+        :return: API client
+        :raise Error: Unknown API or invalid/incomplete environment
+        """
+        for api in cls.KNOWN_APIS:
+            if api.name == api_name:
+                return cls.factory_from_env(
+                    api=api, env_variables_prefix=env_variables_prefix
+                )
+        raise Error(f"Unknown API {api_name}")
+
+    def __init__(
+        self,
+        api_base_path: str,
+        verify: typing.Optional[typing.Union[str, bool]] = None,
+        proxies: typing.Optional[dict] = None,
+        debug_responses: bool = False,
+        trace_json_responses: bool = False,
+    ) -> None:
+        """
+        :param api_base_path: Prefix for any API request
+        :param verify: Optional override to verify validity of SSL connections.
+            See `requests.request()`
+        :param proxies: Optional proxies to use for requests.
+            See `requests.request()`
+        :param debug_responses: If `True`, log detailed API responses.
+            NOTE: This may leak credentials to logs; do not use in production environments where
+            logs are captured
+        :param trace_json_responses: If `True`, print detailed JSON API responses to console.
+            Useful mostly for debugging.
+            NOTE: This may leak credentials to logs; do not use in production environments where
+            logs are captured
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._api_base_path = api_base_path
+        self._verify = verify
+        self._proxies = proxies
+        self._debug_responses = debug_responses
+        self._trace_json_responses = trace_json_responses
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        raise_non_success_status: bool = True,
+        ignored_error_status: typing.Optional[
+            typing.Collection[http.HTTPStatus]
+        ] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """
+        Do a single API request
+
+        :param method: Request method (e.g., GET, POST, DELETE, etc.)
+        :param path: Path (appended to the `api_base_path`) to invoke
+        :param raise_non_success_status: If `True`, raise an exception for any non-success
+            response status-codes
+        :param ignored_error_status: If `raise_non_success_status` is `True`, additionally ignore
+            these non-success response status codes
+        :param kwargs: Optional arguments. See `requests.request()`
+        :raise ApiError: Invoking API failed
+        :return: API response
+        """
+        url = self._api_base_path + path
+        if self._verify is not None and "verify" not in kwargs:
+            kwargs["verify"] = self._verify
+        if self._proxies is not None and "proxies" not in kwargs:
+            kwargs["proxies"] = self._proxies
+
+        self._logger.debug("Invoking API request: %s", url)
+        try:
+            response = requests.request(method=method, url=url, **kwargs)
+        except requests.RequestException as err:
+            self._logger.warning("Invocation of %s failed: %s", url, err)
+            raise ApiError(f"Invocation of {url} failed: {err}") from err
+
+        if self._debug_responses:
+            self._logger.debug("API request %s response: %s", url, response.text)
+        if self._trace_json_responses:
+            try:
+                response_json = response.json()
+            except ValueError:
+                pass  # possibly not JSON
+            else:
+                pprint.pprint(response_json)
+
+        if raise_non_success_status:
+            try:
+                response.raise_for_status()
+            except requests.RequestException as err:
+                if (
+                    ignored_error_status is not None
+                    and response.status_code in ignored_error_status
+                ):
+                    self._logger.debug(
+                        "Ignoring accepted error response status of %s: %s",
+                        url,
+                        response.status_code,
+                    )
+                else:
+                    self._logger.warning(
+                        "Invocation of %s returned non-success (%s): %s",
+                        url,
+                        response.status_code,
+                        err,
+                    )
+                    raise ApiError(
+                        f"Invocation of {url} returned {response.status_code}"
+                    ) from err
+
+        return response
+
+    def get(
+        self,
+        path: str,
+        raise_non_success_status: bool = True,
+        ignored_error_status: typing.Optional[
+            typing.Collection[http.HTTPStatus]
+        ] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """
+        Do a single GET API request
+
+        :param path: Path (appended to the `api_base_path`) to invoke
+        :param raise_non_success_status: If `True`, raise an exception for any non-success
+            response status-codes
+        :param ignored_error_status: If `raise_non_success_status` is `True`, additionally ignore
+            these non-success response status codes
+        :param kwargs: Optional arguments. See `requests.request()`
+        :raise ApiError: Invoking API failed
+        :return: API response
+        """
+        return self.request(
+            method="GET",
+            path=path,
+            raise_non_success_status=raise_non_success_status,
+            ignored_error_status=ignored_error_status,
+            **kwargs,
+        )
+
+    def post(
+        self,
+        path: str,
+        raise_non_success_status: bool = True,
+        ignored_error_status: typing.Optional[
+            typing.Collection[http.HTTPStatus]
+        ] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """
+        Do a single POST API request
+
+        :param path: Path (appended to the `api_base_path`) to invoke
+        :param raise_non_success_status: If `True`, raise an exception for any non-success
+            response status-codes
+        :param ignored_error_status: If `raise_non_success_status` is `True`, additionally ignore
+            these non-success response status codes
+        :param kwargs: Optional arguments. See `requests.request()`
+        :raise ApiError: Invoking API failed
+        :return: API response
+        """
+        return self.request(
+            method="POST",
+            path=path,
+            raise_non_success_status=raise_non_success_status,
+            ignored_error_status=ignored_error_status,
+            **kwargs,
+        )
+
+    def delete(
+        self,
+        path: str,
+        raise_non_success_status: bool = True,
+        ignored_error_status: typing.Optional[
+            typing.Collection[http.HTTPStatus]
+        ] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """
+        Do a single DELETE API request
+
+        :param path: Path (appended to the `api_base_path`) to invoke
+        :param raise_non_success_status: If `True`, raise an exception for any non-success
+            response status-codes
+        :param ignored_error_status: If `raise_non_success_status` is `True`, additionally ignore
+            these non-success response status codes
+        :param kwargs: Optional arguments. See `requests.request()`
+        :raise ApiError: Invoking API failed
+        :return: API response
+        """
+        return self.request(
+            method="DELETE",
+            path=path,
+            raise_non_success_status=raise_non_success_status,
+            ignored_error_status=ignored_error_status,
+            **kwargs,
+        )
+
+
+class IdentityAdminApiClient:
+    """API client for administration of Pixie identities"""
+
+    # OAuth scope for clients in Hydra. This must be the scope used by Pixie when authenticating
+    # clients. Do not change from the default unless you know what you are doing
+    PIXIE_AUTH_SCOPE = "vizier"
+
+    @staticmethod
+    def factory_from_env(
+        env_variables_prefix: str = "",
+    ) -> "IdentityAdminApiClient":
+        """
+        Factory for creating the API client from environment variables
+
+        :param env_variables_prefix: Prefix for the read environment variables)
+        :return: API client
+        :raise Error: Invalid/incomplete environment
+        """
+        return IdentityAdminApiClient(
+            kratos_api_client=ApiRequestHelper.factory_by_known_api_name_from_env(
+                api_name=KnownApiName.KRATOS_ADMIN,
+                env_variables_prefix=env_variables_prefix,
+            ),
+            hydra_api_client=ApiRequestHelper.factory_by_known_api_name_from_env(
+                api_name=KnownApiName.HYDRA_ADMIN,
+                env_variables_prefix=env_variables_prefix,
+            ),
+        )
+
+    def __init__(
+        self,
+        kratos_api_client: ApiRequestHelper,
+        hydra_api_client: ApiRequestHelper,
+        kratos_schema_id: str = "default",
+        grant_types: typing.Collection[str] = ("client_credentials",),
+        auth_scope: str = PIXIE_AUTH_SCOPE,
+    ) -> None:
+        """
+        :param kratos_api_client: Handler for issuing requests to the Kratos administration API
+        :param hydra_api_client: Handler for issuing requests to the Hydra administration API
+        :param kratos_schema_id: Name of the schema for validating the Kratos identity traits
+        :param grant_types: OAuth grant-types to use. We use username+password auth and assume
+            machine-to-machine communication of a trusted client, thus we use "client_credentials".
+            See class doc-string for details
+        :param auth_scope: OAuth scope to use when registering the client in Hydra. This must
+            be the scope used by Pixie when authenticating clients. Do not change from the
+            default unless you know what you are doing
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._kratos_api_client = kratos_api_client
+        self._hydra_api_client = hydra_api_client
+        self._kratos_schema_id = kratos_schema_id
+        self._grant_types = grant_types
+        self._auth_scope = auth_scope
+
+    def delete_identity(self, identity_id: str, ignore_missing: bool = False) -> bool:
+        """
+        Delete the identity
+
+        NOTE: We use the same client ID between Kratos and Hydra. The ID is generated in Kratos,
+        as it forces auto-generation. Hydra allows us to pass the ID in.
+
+        :param identity_id: ID of the identity to delete
+        :param ignore_missing: If `True`, ignore if deletion ends up with a "not found"
+            error (e.g., in case of a race condition between listing and deleting)
+        :return: `True` if the identity was found and deleted; `False` otherwise
+        :raise ApiError: The identity was found but deletion failed
+        """
+        self._logger.info("Deleting identity: %s", identity_id)
+
+        urlencoded_identity_id = urllib.parse.quote(identity_id)
+        ignored_error_status = [http.HTTPStatus.NOT_FOUND] if ignore_missing else None
+
+        self._logger.debug("Deleting Hydra client: %s", identity_id)
+        response = self._hydra_api_client.delete(
+            path=f"/clients/{urlencoded_identity_id}",
+            ignored_error_status=ignored_error_status,
+        )
+        deleted_hydra_client = response.status_code != http.HTTPStatus.NOT_FOUND
+        if deleted_hydra_client:
+            self._logger.debug("Hydra client deletion successful: %s", identity_id)
+        else:
+            self._logger.warning(
+                "Hydra client %s deletion failed: identity not found", identity_id
+            )
+
+        self._logger.debug("Deleting Kratos identity: %s", identity_id)
+        self._kratos_api_client.delete(
+            path=f"/admin/identities/{urlencoded_identity_id}",
+            ignored_error_status=ignored_error_status,
+        )
+        deleted_kratos_identity = response.status_code != http.HTTPStatus.NOT_FOUND
+        if deleted_kratos_identity:
+            self._logger.debug("Kratos identity deletion successful: %s", identity_id)
+        else:
+            self._logger.warning(
+                "Kratos identity %s deletion failed: identity not found",
+                identity_id,
+            )
+
+        return deleted_hydra_client or deleted_kratos_identity
+
+    def delete_identity_by_email_address(
+        self,
+        email_address: str,
+        ignore_missing: bool = True,
+    ) -> bool:
+        """
+        Find the identity with the given email address and delete it
+
+        :param email_address: Email address associated with the identity to delete
+        :param ignore_missing: If `True`, ignore if deletion ends up with a "not found"
+            error (e.g., in case of a race condition between listing and deleting)
+        :return: `True` if the identity was found and deleted; `False` otherwise
+        :raise ApiError: The identity was found but deletion failed
+        """
+        self._logger.info("Finding identity for deletion: %s", email_address)
+        response = self._kratos_api_client.get("/admin/identities")
+        for entry in response.json():
+            try:
+                identity_id = entry["id"]
+                identity_email = entry["traits"]["email"]
+            except (KeyError, ValueError, TypeError) as err:
+                self._logger.warning(
+                    "Got invalid entity from Kratos API (invalid %s): %s", err, entry
+                )
+                continue
+            if identity_email == email_address:
+                self._logger.debug(
+                    "Found identity to delete for email address %s: %s",
+                    identity_email,
+                    identity_id,
+                )
+                return self.delete_identity(
+                    identity_id=identity_id,
+                    ignore_missing=ignore_missing,
+                )
+        return False
+
+    def _create_kratos_identity(self, email_address: str, password: str) -> str:
+        """
+        Create an identity in Kratos
+
+        :param email_address: Email address for the identity
+        :param password: Identity password
+        :return: ID of the newly created Kratos identity
+        :raise ApiError: Talking to Kratos API failed
+        :raise Error: Cannot create identity
+        """
+        self._logger.debug("Creating identity in Kratos: %s", email_address)
+        response = self._kratos_api_client.post(
+            path="/admin/identities",
+            json={
+                "schema_id": self._kratos_schema_id,
+                "traits": {
+                    "email": email_address,
+                },
+                "credentials": {
+                    "password": {
+                        "config": {
+                            "password": password,
+                        },
+                    },
+                },
+            },
+            headers={"Accept": "application/json"},
+            # we have special handling below (with better logging)
+            ignored_error_status=[http.HTTPStatus.CONFLICT],
+        )
+        if response.status_code == http.HTTPStatus.CONFLICT:
+            self._logger.warning("Cannot add Kratos identity %s: exists", email_address)
+            raise Error("Kratos identity exists")
+        if response.status_code != http.HTTPStatus.CREATED:
+            self._logger.warning(
+                "Unexpected Kratos API response for identity creation: %s", response
+            )
+            raise ApiError(
+                f"Unexpected Kratos API response (HTTP-{response.status_code})"
+            )
+        response_json = response.json()
+        identity_id = response_json.get("id")
+        if not identity_id:
+            self._logger.warning(
+                "Unexpected Kratos API response data in identity creation: %s",
+                response_json,
+            )
+            raise ApiError("Unexpected Kratos API response (missing ID)")
+        return identity_id
+
+    def create_identity(
+        self,
+        client_secret: str,
+        email_address: str,
+        password: str,
+    ) -> str:
+        """
+        Create an identity
+
+        :param client_secret: Client secret for authenticating the Machine-To-Machine OAuth client
+        :param email_address: Email address for the identity
+        :param password: Identity password
+        :return: ID of the newly created identity
+        :raise ApiError: Talking to identity APIs failed
+        :raise Error: Cannot create identity
+        """
+        identity_id = self._create_kratos_identity(
+            email_address=email_address,
+            password=password,
+        )
+        # Now that we have an identity in Kratos, we create an OAuth client using the same ID (so
+        # we don't need to maintain multiple IDs)
+        try:
+            self._hydra_api_client.post(
+                path="/clients",
+                json={
+                    "client_id": identity_id,
+                    "client_name": f"Machine-to-machine OAuth client for identity {identity_id}, "
+                    f"administrative identity of Pixie Org registered for {email_address}",
+                    "client_secret": client_secret,
+                    "grant_types": list(self._grant_types),
+                    "scope": self._auth_scope,
+                },
+            )
+        except Error as err:
+            self._logger.warning(
+                "Creating client %s for %s in Hydra failed: %s",
+                identity_id,
+                email_address,
+                err,
+            )
+            raise
+        return identity_id
+
+
+class OAuthApiClient:
+    """
+    API client for performing authentication
+
+    NOTE: In terms of OAuth, this script is client and resource owner at once. As such, we can
+    use a simplified Machine-To-Machine auth-flow that does not involve user-consent via a browser,
+    as that wouldn't make sense here. For details, see
+
+    https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow
+
+    This Machine-To-Machine auth-flow is what is implemented in this class.
+    """
+
+    @staticmethod
+    def factory_from_env(
+        env_variables_prefix: str = "",
+    ) -> "OAuthApiClient":
+        """
+        Factory for creating the API client from environment variables
+
+        :param env_variables_prefix: Prefix for the read environment variables)
+        :return: API client
+        :raise Error: Invalid/incomplete environment
+        """
+        return OAuthApiClient(
+            api_client=ApiRequestHelper.factory_by_known_api_name_from_env(
+                api_name=KnownApiName.HYDRA_USER,
+                env_variables_prefix=env_variables_prefix,
+            ),
+        )
+
+    def __init__(self, api_client: ApiRequestHelper) -> None:
+        """
+        :param api_client: Handler for issuing requests to the Hydra Auth ("user") API
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._api_client = api_client
+
+    def get_access_token(
+        self,
+        username: str,
+        password: str,
+        auth_scope: str = IdentityAdminApiClient.PIXIE_AUTH_SCOPE,
+    ) -> str:
+        """
+        Perform a login to get an access token
+
+        :param username: Identity to login
+        :param password: Password to use for authentication
+        :param auth_scope: OAuth scope to request. See the corresponding parameter in
+            `IdentityAdminApiClient` for details
+        :raise ApiError: The identity was found but deletion failed
+        """
+        self._logger.debug("Performing password login: %s", username)
+        response = self._api_client.post(
+            path="/oauth2/token",
+            auth=(username, password),
+            data={
+                "grant_type": "client_credentials",
+                "scope": auth_scope,
+            },
+            headers={"Accept": "application/json"},
+        )
+        try:
+            return response.json()["access_token"]
+        except (KeyError, ValueError, TypeError) as err:
+            self._logger.warning("Hydra oauth2 login did not return an access_token")
+            raise ApiError("Invalid Hydra response") from err
+
+
+class PixieRegistrationApiClient:
+    """
+    API client for performing Pixie registration
+
+    NOTE: This API client is specifically for the Org registration and initial API access setup.
+    Once this API's workflow has been completed, we should use the standard Pixie API for any
+    complex workflows (i.e., think twice before extending this API client).
+    """
+
+    PIXIE_ORG_NAME_REGEXP = re.compile("^[a-zA-Z0-9][a-zA-Z0-9_.+-]{5,49}$")
+
+    @staticmethod
+    def factory_from_env(
+        env_variables_prefix: str = "",
+    ) -> "PixieRegistrationApiClient":
+        """
+        Factory for creating the API client from environment variables
+
+        :param env_variables_prefix: Prefix for the read environment variables)
+        :return: API client
+        :raise Error: Invalid/incomplete environment
+        """
+        return PixieRegistrationApiClient(
+            api_client=ApiRequestHelper.factory_by_known_api_name_from_env(
+                api_name=KnownApiName.PIXIE,
+                env_variables_prefix=env_variables_prefix,
+            ),
+        )
+
+    def __init__(self, api_client: ApiRequestHelper) -> None:
+        """
+        :param api_client: Handler for issuing requests to the Pixie API
+        """
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._api_client = api_client
+        # NOTE: We don't use sessions but rather drag around the access token across all requests
+        self._api_token = None
+        # User and Pixie Org metadata provided on login (needed for various API calls)
+        self._pixie_user_id = None
+        self._pixie_user_email_address = None
+        self._pixie_org_id = None
+        self._pixie_org_name = None
+
+    def _api_post(
+        self,
+        path: str,
+        **kwargs,
+    ) -> requests.Response:
+        """
+        Helper to send POST request to Pixie API
+
+        NOTE: Can only be used once `self.login()` has been called successfully.
+
+        :param path: Path to invoke
+        :param kwargs: Optional arguments. See `requests.request()`
+        :return: API response
+        """
+        if self._api_token is None:
+            self._logger.warning("Missing login")
+            raise Error("Missing Pixie API login")
+
+        self._logger.debug("Performing API request: %s", path)
+        return self._api_client.post(
+            path=path, headers={"authorization": f"bearer {self._api_token}"}, **kwargs
+        )
+
+    def signup(
+        self,
+        org_name: str,
+        access_token: str,
+    ) -> None:
+        """
+        Perform (one-time) signup for creating the Pixie Org
+
+        NOTE: This method does NOT perform a login. A subsequent call to `login()` is needed, even
+        if this was previously done, as the Pixie API invalidates sessions on Org creation.
+
+        :param org_name: Name of the Pixie Org to use
+        :param access_token: Access-token to use for authentication
+        :raise ApiError: Invoking Pixie API failed
+        """
+        self._logger.info("Performing signup for Pixie Org %s", org_name)
+
+        if not self.PIXIE_ORG_NAME_REGEXP.match(org_name):
+            self._logger.warning("Rejecting invalid Pixie Org: %s", org_name)
+            raise Error("Invalid Pixie Org name")
+
+        response = self._api_client.post(
+            path="/api/auth/signup",
+            json={
+                "accessToken": access_token,
+            },
+            # we want to handle the error ourselves (see below)
+            ignored_error_status=[http.HTTPStatus.INTERNAL_SERVER_ERROR],
+        )
+        if response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR:
+            # The Pixie API doesn't have a very good error-handling for this case: we need to
+            # parse the response in a slightly brittle way
+            if (
+                response.text.strip()
+                == "Failed to signup: cannot create duplicate user"
+            ):
+                self._logger.info("Pixie signup failed: Pixie Org exists")
+                raise Error("Pixie Org signup failed: Org exists")
+
+            self._logger.warning(
+                "Pixie signup failed (status-code %s): %s",
+                response.text,
+                response.status_code,
+            )
+            raise Error("Pixie Org signup failed")
+
+        try:
+            pixie_token = response.json()["token"]
+        except (KeyError, ValueError, TypeError) as err:
+            self._logger.warning(
+                "Pixie signup successful but missing token in response"
+            )
+            raise ApiError("Pixie Org signup did not return token") from err
+        self._logger.info("Signup for Pixie Org %s successful", org_name)
+
+        # temporarily sign in for the rest of the API calls - reset when we exit the function
+        self._api_token = pixie_token
+        try:
+            # check auth working as expected
+            self._api_post(path="/api/authorized")
+            self._do_graphql_operation(
+                operation_name="CreateOrgFromSetupOrgPage",
+                variables={
+                    "orgName": org_name,
+                },
+                query="""mutation CreateOrgFromSetupOrgPage($orgName: String!) {
+                    CreateOrg(orgName: $orgName)
+                }
+                """,
+            )
+        finally:
+            # seems Org creation messes with tokens. Enforce a login after signup, no matter what
+            self._api_token = None
+
+    def login(self, access_token: str) -> None:
+        """
+        Login to the Pixie API
+
+        NOTE: Calling this method resets the connection to the API (if one exists), regardless of
+        the outcome of the login.
+
+        :param access_token: Access-token to use for authentication. If `None` is provided, use the
+            access-token of a previous call to `login()`
+        :raise ApiError: Invoking Pixie API failed
+        """
+        self._logger.debug("Performing API login")
+
+        # see doc-string - we don't want a complicated/confusing state depending on the type of
+        # failure
+        self._api_token = None
+        self._pixie_user_id = None
+        self._pixie_user_email_address = None
+        self._pixie_org_id = None
+        self._pixie_org_name = None
+
+        response = self._api_client.post(
+            path="/api/auth/login",
+            json={
+                "accessToken": access_token,
+            },
+        )
+        response_json = response.json()
+        try:
+            # NOTE: We update the client object (below) only if all values were read successfully,
+            # hence the temporary variables
+            pixie_token = response_json["token"]
+            pixie_user_info = response_json["userInfo"]
+            pixie_user_id = pixie_user_info["userID"]
+            pixie_user_email_address = pixie_user_info["email"]
+            pixie_org_info = response_json["orgInfo"]
+            pixie_org_id = pixie_org_info["orgID"]
+            pixie_org_name = pixie_org_info["orgName"]
+        except (KeyError, ValueError, TypeError) as err:
+            self._logger.warning(
+                "Login successful but missing data in response: %s", err
+            )
+            raise ApiError("Pixie login did not return expected data") from err
+        self._api_token = pixie_token
+        self._pixie_user_id = pixie_user_id
+        self._pixie_user_email_address = pixie_user_email_address
+        self._pixie_org_id = pixie_org_id
+        self._pixie_org_name = pixie_org_name
+
+    def _do_graphql_operation(
+        self,
+        operation_name: str,
+        query: str,
+        variables: typing.Optional[dict] = None,
+    ) -> dict:
+        """
+        Perform a graphql API request
+
+        :param operation_name: Name of the operation to perform
+        :param query: Operation to execute
+        :return: Operation response
+        :raise ApiError: Invoking Pixie API failed
+        """
+        self._logger.debug("Invoking GraphQL API method: %s", operation_name)
+        response = self._api_post(
+            path="/api/graphql",
+            json={
+                "operationName": operation_name,
+                "variables": {} if variables is None else variables,
+                "query": query,
+            },
+        )
+        try:
+            return response.json()["data"]
+        except (KeyError, ValueError, TypeError) as err:
+            self._logger.warning(
+                "Invoking API method %s failed: missing %s", operation_name, err
+            )
+            raise ApiError(f"GraphQL API response invalid: {err}") from err
+
+    def _create_id_entity(
+        self,
+        entity_type_name: str,
+        create_operation_name: str,
+        create_query_name: str,
+        get_operation_name: str,
+        get_query_name: str,
+    ) -> typing.Tuple[str, str]:
+        """
+        Helper for creating ID:KEY entities in the API
+
+        NOTE: Several entities in the API follow the same concepts/structures. This helper exists
+        merely to avoid code duplication
+
+        NOTE: The graphQL schema supports a "desc" field for most entities, but the API does not
+        currently allow setting it in the mutations (it is not accepted as parameter).
+
+        :param entity_type_name: Name of the API entity type to create (for logging)
+        :param create_operation_name: Name of the operation to invoke for creation
+        :param create_query_name: Name of the query to invoke for creation
+        :param get_operation_name: Name of the operation to invoke for retrieval
+        :param get_query_name: Query to invoke for retrieval
+        :return: Entity ID and key
+        :raise ApiError: Invoking Pixie API failed
+        """
+        self._logger.info("Creating %s", entity_type_name)
+
+        data = self._do_graphql_operation(
+            operation_name=create_operation_name,
+            query=f"""mutation {create_operation_name}() {{
+                {create_query_name}() {{
+                    id
+                    desc
+                    createdAtMs
+                    __typename
+                }}
+            }}
+            """,
+        )
+        try:
+            entity_id = data[create_query_name]["id"]
+        except (KeyError, ValueError, TypeError) as err:
+            self._logger.warning(
+                "Invalid response from %s API: %s", create_operation_name, err
+            )
+            raise ApiError(
+                f"Response from {create_operation_name} is invalid: {err}"
+            ) from err
+
+        self._logger.debug("Creating %s successful: %s", entity_type_name, entity_id)
+        data = self._do_graphql_operation(
+            operation_name=get_operation_name,
+            variables={
+                "id": entity_id,
+            },
+            query=f"""query {get_operation_name}($id: ID!) {{
+                {get_query_name}(id: $id) {{
+                    id
+                    key
+                    desc
+                    __typename
+                }}
+            }}
+            """,
+        )
+        try:
+            entity_key = data[get_query_name]["key"]
+        except (KeyError, ValueError, TypeError) as err:
+            self._logger.warning(
+                "Invalid response from %s API: %s", get_operation_name, err
+            )
+            raise ApiError(
+                f"Response from {get_operation_name} invalid: {err}"
+            ) from err
+
+        self._logger.debug("Fetched %s %s secret", entity_type_name, entity_id)
+        return entity_id, entity_key
+
+    def create_api_key(self) -> typing.Tuple[str, str]:
+        """
+        Create an API key
+
+        NOTE: The graphQL schema supports a "desc" field for API-keys, but the API does
+        not currently allow setting it in the mutations (it is not accepted as parameter).
+
+        :return: API key ID and key-secret
+        :raise ApiError: Invoking Pixie API failed
+        """
+        return self._create_id_entity(
+            entity_type_name="API key",
+            create_operation_name="CreateAPIKeyFromAdminPage",
+            create_query_name="CreateAPIKey",
+            get_operation_name="getAPIKey",
+            get_query_name="apiKey",
+        )
+
+    def create_deployment_key(self) -> typing.Tuple[str, str]:
+        """
+        Create a deployment-key
+
+        NOTE: The graphQL schema supports a "desc" field for deployment-keys, but the API does
+        not currently allow setting it in the mutations (it is not accepted as parameter).
+
+        :return: Deployment key ID and key-secret
+        :raise ApiError: Invoking Pixie API failed
+        """
+        return self._create_id_entity(
+            entity_type_name="deployment key",
+            create_operation_name="CreateDeploymentKeyFromAdminPage",
+            create_query_name="CreateDeploymentKey",
+            get_operation_name="getDeploymentKey",
+            get_query_name="deploymentKey",
+        )
+
+    def configure_org_settings(
+        self,
+        enable_user_approvals: bool,
+    ) -> None:
+        """
+        Configure the Pixie Org settings
+
+        :param enable_user_approvals: If `True`, require new users to be approved before being
+            able to access the org; Otherwise, Pixie will allow any user who registers in the org
+            to log in and use Pixie without approval
+        :raise ApiError: Invoking Pixie API failed
+        """
+        self._logger.info("Configuring Pixie user approvals: %s", enable_user_approvals)
+
+        # NOTE: Once we have multiple options supported, we might want to allow passing in `None`
+        # to update only those parameters that are `True` or `False`. Alternatively, we can get
+        # the current settings, patch, and post back
+        self._do_graphql_operation(
+            operation_name="UpdateOrgApprovalSetting",
+            variables={
+                "orgID": self._pixie_org_id,
+                "enableApprovals": enable_user_approvals,
+            },
+            query="""mutation UpdateOrgApprovalSetting($orgID: ID!, $enableApprovals: Boolean!) {
+                UpdateOrgSettings(
+                    orgID: $orgID
+                    orgSettings: {enableApprovals: $enableApprovals}
+                ) {
+                    id
+                    name
+                    enableApprovals
+                    __typename
+                }
+            }
+            """,
+        )
+        self._logger.info("Pixie Org approval setting: updated successfully")
+
+    def configure_user_settings(
+        self,
+        enable_analytics: bool,
+    ) -> None:
+        """
+        Configure the Pixie Org settings
+
+        :param enable_analytics: If `True`, enable tracking of UI analytics for this
+            user; Otherwise disable tracking
+        :raise ApiError: Invoking Pixie API failed
+        """
+        self._logger.info(
+            "Configuring Pixie user-settings: ui-analytics=%s", enable_analytics
+        )
+
+        # NOTE: Once we have multiple options supported, we might want to allow passing in `None`
+        # to update only those parameters that are `True` or `False`. Alternatively, we can get
+        # the current settings, patch, and post back
+        self._do_graphql_operation(
+            operation_name="UpdateUserAnalyticOptOut",
+            variables={
+                "analyticsOptout": not enable_analytics,
+            },
+            query="""mutation UpdateUserAnalyticOptOut($analyticsOptout: Boolean!) {
+                UpdateUserSettings(
+                    settings: {analyticsOptout: $analyticsOptout}
+                ) {
+                    id
+                    analyticsOptout
+                    __typename
+                }
+            }
+            """,
+        )
+        self._logger.info("Pixie Org user settings: updated successfully")

--- a/src/api/python/tests/BUILD.bazel
+++ b/src/api/python/tests/BUILD.bazel
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//bazel:pl_build_system.bzl", "pl_py_test")
+load("@vizier_api_python_deps//:requirements.bzl", "requirement")
 
 pl_py_test(
     name = "api_test",
@@ -41,5 +42,19 @@ pl_py_test(
     deps = [
         "//src/api/python/pxapi:pxapi_library",
         "//src/api/python/tests/helpers:test_utils",
+    ],
+)
+
+pl_py_test(
+    name = "self_hosted_registration_test",
+    srcs = ["self_hosted_registration_test.py"],
+    imports = [
+        "../",
+    ],
+    srcs_version = "PY3",
+    deps = [
+        "//src/api/python/self_hosted_registration:self_hosted_registration_library",
+        requirement("ddt"),
+        requirement("requests"),
     ],
 )

--- a/src/api/python/tests/self_hosted_registration_test.py
+++ b/src/api/python/tests/self_hosted_registration_test.py
@@ -1,0 +1,1508 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import http
+import os
+import unittest
+import unittest.mock
+
+import ddt
+import requests
+
+from self_hosted_registration import registration
+
+
+# Some of the test methods don't have doc-strings, because we use `ddt` which will add
+# doc-strings based on the values that are added from `ddt.data`. If we had a doc-string,
+# the decorator would not do that and it's hard to track down which tests fail
+#
+# And we want to keep tests together - breaking it up artificially doesn't make sense
+# for tests
+#
+# pylint: disable=missing-function-docstring,too-many-lines
+
+
+@ddt.ddt
+class TestApiRequestHelper(unittest.TestCase):
+    """
+    Test request helpers in `ApiRequestHelper`
+    """
+
+    def test_factory_from_cli(self) -> None:
+        """
+        Test parsing API configs from `argparse`
+        """
+        args = argparse.Namespace()
+        args.kratos_admin_url = "test-kratos-url"
+        args.kratos_admin_insecure = True
+        args.verbose = True
+
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_cli
+
+        mock_helper = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            mock_constructor.return_value = mock_helper
+            helper = test_factory(
+                api_name=registration.KnownApiName.KRATOS_ADMIN,
+                args=args,
+            )
+            mock_constructor.assert_called_once_with(
+                api_base_path="test-kratos-url",
+                debug_responses=False,
+                trace_json_responses=False,
+                verify=False,
+            )
+        self.assertIs(helper, mock_helper)
+
+    def test_factory_from_cli_unknown_api(self) -> None:
+        """
+        Test parsing API configs from `argparse` of an unknown API
+
+        NOTE: This test is a bit constructed and mostly for code-coverage. As we're using
+        enums, the covered path is usually not reachable but implemented for completeness sake
+        """
+        with self.assertRaises(registration.Error) as err:
+            registration.ApiRequestHelper.factory_by_known_api_name_from_cli(
+                api_name=unittest.mock.MagicMock(registration.KnownApiName),
+                args=argparse.Namespace(),
+            )
+        self.assertIn(
+            "Unknown API <MagicMock spec='KnownApiName' id=", str(err.exception)
+        )
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {
+            "TEST_KRATOS_ADMIN_URL": "test-kratos-url",
+            "TEST_KRATOS_ADMIN_DEBUG_RESPONSES": "true",
+            "TEST_KRATOS_ADMIN_VERIFY": "test-verify",
+        },
+        clear=True,
+    )
+    def test_factory_from_env(self) -> None:
+        """
+        Test parsing API configs from environment
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_env
+
+        mock_helper = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            mock_constructor.return_value = mock_helper
+            helper = test_factory(
+                api_name=registration.KnownApiName.KRATOS_ADMIN,
+                env_variables_prefix="TEST_",
+            )
+            mock_constructor.assert_called_once_with(
+                api_base_path="test-kratos-url",
+                debug_responses=True,
+                trace_json_responses=True,
+                verify="test-verify",
+            )
+        self.assertIs(helper, mock_helper)
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {
+            "TEST_KRATOS_ADMIN_URL": "test-kratos-url",
+        },
+        clear=True,
+    )
+    def test_factory_from_env_minimal_env(self) -> None:
+        """
+        Test parsing API configs from environment: minimal environment settings
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_env
+
+        mock_helper = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            mock_constructor.return_value = mock_helper
+            helper = test_factory(
+                api_name=registration.KnownApiName.KRATOS_ADMIN,
+                env_variables_prefix="TEST_",
+            )
+            mock_constructor.assert_called_once_with(
+                api_base_path="test-kratos-url",
+                debug_responses=False,
+                trace_json_responses=False,
+                verify=None,
+            )
+        self.assertIs(helper, mock_helper)
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {
+            "TEST_KRATOS_ADMIN_URL": "test-kratos-url",
+            "TEST_KRATOS_ADMIN_INSECURE": "true",
+        },
+        clear=True,
+    )
+    def test_factory_from_env_insecure(self) -> None:
+        """
+        Test parsing API configs from environment: disable SSL validation
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_env
+
+        mock_helper = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            mock_constructor.return_value = mock_helper
+            helper = test_factory(
+                api_name=registration.KnownApiName.KRATOS_ADMIN,
+                env_variables_prefix="TEST_",
+            )
+            mock_constructor.assert_called_once_with(
+                api_base_path="test-kratos-url",
+                debug_responses=False,
+                trace_json_responses=False,
+                verify=False,
+            )
+        self.assertIs(helper, mock_helper)
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {
+            "TEST_KRATOS_ADMIN_URL": "test-kratos-url",
+            "TEST_KRATOS_ADMIN_INSECURE": "false",
+        },
+        clear=True,
+    )
+    def test_factory_from_env_secure_explicit(self) -> None:
+        """
+        Test parsing API configs from environment: configure SSL validation
+
+        NOTE: This is covering extra code-paths that are actually identical to the default
+        configuration
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_env
+
+        mock_helper = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            mock_constructor.return_value = mock_helper
+            helper = test_factory(
+                api_name=registration.KnownApiName.KRATOS_ADMIN,
+                env_variables_prefix="TEST_",
+            )
+            mock_constructor.assert_called_once_with(
+                api_base_path="test-kratos-url",
+                debug_responses=False,
+                trace_json_responses=False,
+                verify=None,
+            )
+        self.assertIs(helper, mock_helper)
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {
+            "TEST_KRATOS_ADMIN_URL": "test-kratos-url",
+            "TEST_KRATOS_ADMIN_INSECURE": "this-is-not-a-bool",
+        },
+        clear=True,
+    )
+    def test_factory_from_env_invalid_config(self) -> None:
+        """
+        Test parsing API configs from environment: invalid configuration
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_env
+
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            with self.assertRaises(registration.Error) as err:
+                test_factory(
+                    api_name=registration.KnownApiName.KRATOS_ADMIN,
+                    env_variables_prefix="TEST_",
+                )
+            mock_constructor.assert_not_called()
+        self.assertEqual(
+            str(err.exception),
+            "Cannot instantiate Kratos Admin from env: invalid bool value this-is-not-a-bool "
+            "for TEST_KRATOS_ADMIN_INSECURE",
+        )
+
+    @unittest.mock.patch.dict(os.environ, {}, clear=True)
+    def test_factory_from_env_incomplete_env(self) -> None:
+        """
+        Test parsing API configs from environment: missing values
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.ApiRequestHelper.factory_by_known_api_name_from_env
+
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.ApiRequestHelper", autospec=True
+        ) as mock_constructor:
+            with self.assertRaises(registration.Error) as err:
+                test_factory(
+                    api_name=registration.KnownApiName.KRATOS_ADMIN,
+                    env_variables_prefix="TEST_",
+                )
+            mock_constructor.assert_not_called()
+        self.assertEqual(
+            str(err.exception),
+            "Cannot instantiate Kratos Admin from env: missing TEST_KRATOS_ADMIN_URL",
+        )
+
+    def test_factory_from_env_unknown_api(self) -> None:
+        """
+        Test parsing API configs from environment of an unknown API
+
+        NOTE: This test is a bit constructed and mostly for code-coverage. As we're using
+        enums, the covered path is usually not reachable but implemented for completeness sake
+        """
+        with self.assertRaises(registration.Error) as err:
+            registration.ApiRequestHelper.factory_by_known_api_name_from_env(
+                api_name=unittest.mock.MagicMock(registration.KnownApiName),
+            )
+        self.assertIn(
+            "Unknown API <MagicMock spec='KnownApiName' id=", str(err.exception)
+        )
+
+    @unittest.mock.patch("requests.request", autospec=True)
+    def test_request(self, mocked_request) -> None:
+        """
+        Test wrapper is propagating all parameters as expected to the requests library
+        """
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mocked_request.return_value = mock_response
+
+        test_helper = registration.ApiRequestHelper(
+            api_base_path="http://test-base-path",
+            verify=False,
+            proxies={"test": "proxy"},
+            debug_responses=True,
+            trace_json_responses=True,
+        )
+        test_helper.request(
+            method="PATCH",
+            path="/test/path",
+            ignored_error_status=[http.HTTPStatus.ACCEPTED],
+            some_other_requests_parameter="test-parameter-value",
+        )
+        mocked_request.assert_called_once_with(
+            method="PATCH",
+            url="http://test-base-path/test/path",
+            verify=False,
+            proxies={"test": "proxy"},
+            some_other_requests_parameter="test-parameter-value",
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @unittest.mock.patch("requests.request", autospec=True)
+    def test_request_error(self, mocked_request) -> None:
+        """
+        Test wrapper is propagating request errors: failing request
+        """
+        mocked_request.side_effect = requests.RequestException("test-error")
+
+        test_helper = registration.ApiRequestHelper(
+            api_base_path="http://test-base-path"
+        )
+        with self.assertRaises(registration.ApiError) as err:
+            test_helper.request(
+                method="GET",
+                path="",
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Invocation of http://test-base-path failed: test-error",
+        )
+        mocked_request.assert_called_once_with(
+            method="GET",
+            url="http://test-base-path",
+        )
+
+    @unittest.mock.patch("requests.request", autospec=True)
+    def test_request_response_error(self, mocked_request) -> None:
+        """
+        Test wrapper is propagating response errors: HTTP response is an error
+        """
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.raise_for_status.side_effect = requests.RequestException(
+            "test-error"
+        )
+        mock_response.json.side_effect = ValueError("test-error")
+        mock_response.status_code = http.HTTPStatus.NOT_FOUND.value
+
+        mocked_request.return_value = mock_response
+
+        test_helper = registration.ApiRequestHelper(
+            api_base_path="http://test-base-path",
+            debug_responses=True,
+            trace_json_responses=True,
+        )
+        with self.assertRaises(registration.ApiError) as err:
+            test_helper.request(
+                method="GET",
+                path="",
+            )
+        self.assertEqual(
+            str(err.exception),
+            "Invocation of http://test-base-path returned 404",
+        )
+        mocked_request.assert_called_once_with(
+            method="GET",
+            url="http://test-base-path",
+        )
+        mock_response.json.assert_called_once()
+        mock_response.raise_for_status.assert_called_once()
+
+    @unittest.mock.patch("requests.request", autospec=True)
+    def test_request_ignore_response_error(self, mocked_request) -> None:
+        """
+        Test wrapper is propagating response errors: HTTP response is an ignored error
+        """
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.raise_for_status.side_effect = requests.RequestException(
+            "test-error"
+        )
+        mock_response.status_code = http.HTTPStatus.NOT_FOUND.value
+
+        mocked_request.return_value = mock_response
+
+        test_helper = registration.ApiRequestHelper(
+            api_base_path="http://test-base-path",
+            debug_responses=True,
+            trace_json_responses=True,
+        )
+        response = test_helper.request(
+            method="GET",
+            path="",
+            ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+        )
+        self.assertEqual(response.status_code, http.HTTPStatus.NOT_FOUND)
+        mocked_request.assert_called_once_with(
+            method="GET",
+            url="http://test-base-path",
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+    @ddt.data("GET", "POST", "DELETE")
+    def test_request_for_request_method(self, request_method: str) -> None:
+        # Test <request_method> requests propagate parameters as expected
+        #
+        # NOTE: Most functionality is tested in `self.test_request*`. This test merely ensures
+        # this internal helper is invoked properly as the tested method does not add logic itself
+        test_helper = registration.ApiRequestHelper(
+            api_base_path="http://test-base-path",
+        )
+        mock_response = unittest.mock.MagicMock(requests.Response)
+
+        with unittest.mock.patch.object(
+            registration.ApiRequestHelper, "request"
+        ) as mock_request:
+            mock_request.return_value = mock_response
+
+            test_helper_method = getattr(test_helper, request_method.lower())
+            response = test_helper_method(
+                path="/test/path",
+                raise_non_success_status=False,
+                ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+                some_other_requests_parameter="test-parameter-value",
+            )
+
+            self.assertIs(response, mock_response)
+            mock_request.assert_called_once_with(
+                method=request_method,
+                path="/test/path",
+                raise_non_success_status=False,
+                ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+                some_other_requests_parameter="test-parameter-value",
+            )
+
+    def test_post(self) -> None:
+        """
+        Test POST requests propagate parameters as expected
+
+        NOTE: Most functionality is tested in `self.test_request*`. This test merely ensures this
+        internal helper is invoked properly as the tested method does not add logic itself
+        """
+        test_helper = registration.ApiRequestHelper(
+            api_base_path="http://test-base-path",
+        )
+        mock_response = unittest.mock.MagicMock(requests.Response)
+
+        with unittest.mock.patch.object(
+            registration.ApiRequestHelper, "request"
+        ) as mock_request:
+            mock_request.return_value = mock_response
+            response = test_helper.post(
+                path="/test/path",
+                raise_non_success_status=False,
+                ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+                some_other_requests_parameter="test-parameter-value",
+            )
+            self.assertIs(response, mock_response)
+            mock_request.assert_called_once_with(
+                method="POST",
+                path="/test/path",
+                raise_non_success_status=False,
+                ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+                some_other_requests_parameter="test-parameter-value",
+            )
+
+
+class TestIdentityAdminApiClient(unittest.TestCase):
+    """
+    Test `IdentityAdminApiClient`
+    """
+
+    @unittest.mock.patch.object(
+        # NOTE: We use `unittest.mock.patch.object()` because a the mock module has a bug that
+        # does not allow us to patch a staticmethod (and also doesn't allow `autospec=True`)
+        #
+        # https://bugs.python.org/issue23078
+        #
+        registration.ApiRequestHelper,
+        "factory_by_known_api_name_from_env",
+    )
+    def test_factory_from_env(self, mock_api_request_helper_factory) -> None:
+        """
+        Test instantiating from the environment
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.IdentityAdminApiClient.factory_from_env
+
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_identity_client = unittest.mock.MagicMock(
+            registration.IdentityAdminApiClient
+        )
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.IdentityAdminApiClient",
+            autospec=True,
+        ) as mock_constructor:
+            mock_api_request_helper_factory.side_effect = [
+                mock_kratos_api_client,
+                mock_hydra_api_client,
+            ]
+            mock_constructor.return_value = mock_identity_client
+
+            identity_client = test_factory(env_variables_prefix="TEST_")
+            self.assertIs(identity_client, mock_identity_client)
+
+            mock_constructor.assert_called_once_with(
+                kratos_api_client=mock_kratos_api_client,
+                hydra_api_client=mock_hydra_api_client,
+            )
+
+        mock_api_request_helper_factory.assert_has_calls(
+            [
+                unittest.mock.call(
+                    api_name=registration.KnownApiName.KRATOS_ADMIN,
+                    env_variables_prefix="TEST_",
+                ),
+                unittest.mock.call(
+                    api_name=registration.KnownApiName.HYDRA_ADMIN,
+                    env_variables_prefix="TEST_",
+                ),
+            ]
+        )
+
+    def test_delete_identity(self) -> None:
+        """
+        Test deleting an identity
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        deleted = test_identity_client.delete_identity(identity_id="test-identity-id")
+        self.assertTrue(deleted)
+
+        mock_kratos_api_client.delete.assert_called_once_with(
+            path="/admin/identities/test-identity-id",
+            ignored_error_status=None,
+        )
+        mock_hydra_api_client.delete.assert_called_once_with(
+            path="/clients/test-identity-id",
+            ignored_error_status=None,
+        )
+
+    def test_delete_identity_unknown_identity(self) -> None:
+        """
+        Test deleting an identity that does not exist
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.NOT_FOUND.value
+        mock_kratos_api_client.delete.return_value = mock_kratos_response
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_hydra_response = unittest.mock.MagicMock(requests.Response)
+        mock_hydra_response.status_code = http.HTTPStatus.NOT_FOUND.value
+        mock_hydra_api_client.delete.return_value = mock_hydra_response
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        deleted = test_identity_client.delete_identity(
+            identity_id="test-identity-id",
+            ignore_missing=True,
+        )
+        self.assertFalse(deleted)
+
+        mock_kratos_api_client.delete.assert_called_once_with(
+            path="/admin/identities/test-identity-id",
+            ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+        )
+        mock_hydra_api_client.delete.assert_called_once_with(
+            path="/clients/test-identity-id",
+            ignored_error_status=[http.HTTPStatus.NOT_FOUND],
+        )
+
+    def test_delete_identity_by_email_address(self) -> None:
+        """
+        Test deleting an identity from its email address
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.NOT_FOUND.value
+        mock_kratos_response.json.return_value = [
+            {
+                "id": "some-ignored-id",
+                "traits": {
+                    "email": "some-ignored@test",
+                },
+            },
+            {"id": "some-corrupted-entry-that-should-be-ignored-too"},
+            {
+                "id": "test-identity-id",
+                "traits": {
+                    "email": "test-identity@test",
+                },
+            },
+        ]
+        mock_kratos_api_client.get.return_value = mock_kratos_response
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+
+        with unittest.mock.patch.object(
+            registration.IdentityAdminApiClient, "delete_identity"
+        ) as mock_delete_identity:
+            mock_delete_identity.return_value = True
+
+            deleted = test_identity_client.delete_identity_by_email_address(
+                email_address="test-identity@test",
+                ignore_missing=False,
+            )
+            self.assertTrue(deleted)
+
+            mock_delete_identity.assert_called_once_with(
+                identity_id="test-identity-id",
+                ignore_missing=False,
+            )
+
+        mock_kratos_api_client.get.assert_called_once_with("/admin/identities")
+        mock_kratos_response.json.assert_called_once()
+
+    def test_delete_identity_by_email_address_not_found(self) -> None:
+        """
+        Test deleting an identity from its email address for an unknown identity
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.NOT_FOUND.value
+        mock_kratos_response.json.return_value = [
+            {
+                "id": "some-ignored-id",
+                "traits": {
+                    "email": "some-ignored@test",
+                },
+            },
+        ]
+        mock_kratos_api_client.get.return_value = mock_kratos_response
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+
+        with unittest.mock.patch.object(
+            registration.IdentityAdminApiClient, "delete_identity"
+        ) as mock_delete_identity:
+            deleted = test_identity_client.delete_identity_by_email_address(
+                email_address="test-identity@test",
+                ignore_missing=False,
+            )
+            self.assertFalse(deleted)
+
+            mock_delete_identity.assert_not_called()
+
+        mock_kratos_api_client.get.assert_called_once_with("/admin/identities")
+        mock_kratos_response.json.assert_called_once()
+
+    def test_create_identity(self) -> None:
+        """
+        Test creating an identity
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.CREATED.value
+        mock_kratos_response.json.return_value = {"id": "test-identity-id"}
+        mock_kratos_api_client.post.return_value = mock_kratos_response
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        identity_id = test_identity_client.create_identity(
+            client_secret="test-secret",
+            email_address="test-identity@test",
+            password="test-password",
+        )
+        self.assertEqual(identity_id, "test-identity-id")
+
+        mock_kratos_api_client.post.assert_called_once_with(
+            path="/admin/identities",
+            json={
+                "schema_id": "default",
+                "traits": {
+                    "email": "test-identity@test",
+                },
+                "credentials": {
+                    "password": {
+                        "config": {
+                            "password": "test-password",
+                        },
+                    },
+                },
+            },
+            headers={"Accept": "application/json"},
+            ignored_error_status=[http.HTTPStatus.CONFLICT],
+        )
+        mock_kratos_response.json.assert_called_once()
+        mock_hydra_api_client.post.assert_called_once_with(
+            path="/clients",
+            json={
+                "client_id": "test-identity-id",
+                "client_name": "Machine-to-machine OAuth client for identity test-identity-id, "
+                "administrative identity of Pixie Org registered for test-identity@test",
+                "client_secret": "test-secret",
+                "grant_types": ["client_credentials"],
+                "scope": "vizier",
+            },
+        )
+
+    def test_create_identity_exists(self) -> None:
+        """
+        Test creating an identity that clashes with an existing one in Kratos
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.CONFLICT.value
+        mock_kratos_api_client.post.return_value = mock_kratos_response
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_identity_client.create_identity(
+                client_secret="test-secret",
+                email_address="test-identity@test",
+                password="test-password",
+            )
+        self.assertEqual(str(err.exception), "Kratos identity exists")
+
+        mock_kratos_api_client.post.assert_called_once_with(
+            path="/admin/identities",
+            json=unittest.mock.ANY,
+            headers=unittest.mock.ANY,
+            ignored_error_status=unittest.mock.ANY,
+        )
+        mock_hydra_api_client.post.assert_not_called()
+
+    def test_create_identity_kratos_error_status(self) -> None:
+        """
+        Test creating an identity error: Unexpected Kratos API response
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.OK.value
+        mock_kratos_api_client.post.return_value = mock_kratos_response
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_identity_client.create_identity(
+                client_secret="test-secret",
+                email_address="test-identity@test",
+                password="test-password",
+            )
+        self.assertEqual(
+            str(err.exception), "Unexpected Kratos API response (HTTP-200)"
+        )
+
+        mock_kratos_api_client.post.assert_called_once_with(
+            path="/admin/identities",
+            json=unittest.mock.ANY,
+            headers=unittest.mock.ANY,
+            ignored_error_status=unittest.mock.ANY,
+        )
+        mock_hydra_api_client.post.assert_not_called()
+
+    def test_create_identity_kratos_missing_id(self) -> None:
+        """
+        Test creating an identity error: Unexpected Kratos API response (missing ID)
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.CREATED.value
+        mock_kratos_response.json.return_value = {}
+        mock_kratos_api_client.post.return_value = mock_kratos_response
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_identity_client.create_identity(
+                client_secret="test-secret",
+                email_address="test-identity@test",
+                password="test-password",
+            )
+        self.assertEqual(
+            str(err.exception), "Unexpected Kratos API response (missing ID)"
+        )
+
+        mock_kratos_api_client.post.assert_called_once_with(
+            path="/admin/identities",
+            json=unittest.mock.ANY,
+            headers=unittest.mock.ANY,
+            ignored_error_status=unittest.mock.ANY,
+        )
+        mock_hydra_api_client.post.assert_not_called()
+
+    def test_create_identity_hydra_error_status(self) -> None:
+        """
+        Test creating an identity error: Unexpected Hydra API response
+        """
+        mock_kratos_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_kratos_response = unittest.mock.MagicMock(requests.Response)
+        mock_kratos_response.status_code = http.HTTPStatus.CREATED.value
+        mock_kratos_response.json.return_value = {"id": "test-identity-id"}
+        mock_kratos_api_client.post.return_value = mock_kratos_response
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_hydra_api_client.post.side_effect = registration.ApiError("test-error")
+
+        test_identity_client = registration.IdentityAdminApiClient(
+            kratos_api_client=mock_kratos_api_client,
+            hydra_api_client=mock_hydra_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_identity_client.create_identity(
+                client_secret="test-secret",
+                email_address="test-identity@test",
+                password="test-password",
+            )
+        self.assertEqual(str(err.exception), "test-error")
+
+        mock_kratos_api_client.post.assert_called_once_with(
+            path="/admin/identities",
+            json=unittest.mock.ANY,
+            headers=unittest.mock.ANY,
+            ignored_error_status=unittest.mock.ANY,
+        )
+        mock_kratos_response.json.assert_called_once()
+        mock_hydra_api_client.post.assert_called_once_with(
+            path="/clients",
+            json=unittest.mock.ANY,
+        )
+
+
+class TestOAuthApiClient(unittest.TestCase):
+    """
+    Test `OAuthApiClient`
+    """
+
+    @unittest.mock.patch.object(
+        # NOTE: We use `unittest.mock.patch.object()` because a the mock module has a bug that
+        # does not allow us to patch a staticmethod (and also doesn't allow `autospec=True`)
+        #
+        # https://bugs.python.org/issue23078
+        #
+        registration.ApiRequestHelper,
+        "factory_by_known_api_name_from_env",
+    )
+    def test_factory_from_env(self, mock_api_request_helper_factory) -> None:
+        """
+        Test instantiating from the environment
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.OAuthApiClient.factory_from_env
+
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_oauth_client = unittest.mock.MagicMock(registration.OAuthApiClient)
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.OAuthApiClient", autospec=True
+        ) as mock_constructor:
+            mock_api_request_helper_factory.return_value = mock_hydra_api_client
+            mock_constructor.return_value = mock_oauth_client
+
+            oauth_client = test_factory(env_variables_prefix="TEST_")
+            self.assertIs(oauth_client, mock_oauth_client)
+
+            mock_constructor.assert_called_once_with(api_client=mock_hydra_api_client)
+
+        mock_api_request_helper_factory.assert_called_once_with(
+            api_name=registration.KnownApiName.HYDRA_USER,
+            env_variables_prefix="TEST_",
+        )
+
+    def test_get_access_token(self) -> None:
+        """
+        Test authenticating to get an access-token
+        """
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_hydra_response = unittest.mock.MagicMock(requests.Response)
+        mock_hydra_response.status_code = http.HTTPStatus.OK.value
+        mock_hydra_response.json.return_value = {"access_token": "test-access-token"}
+        mock_hydra_api_client.post.return_value = mock_hydra_response
+
+        test_oauth_client = registration.OAuthApiClient(
+            api_client=mock_hydra_api_client,
+        )
+        access_token = test_oauth_client.get_access_token(
+            username="test-username",
+            password="test-password",
+        )
+        self.assertEqual(access_token, "test-access-token")
+
+        mock_hydra_api_client.post.assert_called_once_with(
+            path="/oauth2/token",
+            auth=("test-username", "test-password"),
+            data={
+                "grant_type": "client_credentials",
+                "scope": "vizier",
+            },
+            headers={"Accept": "application/json"},
+        )
+
+    def test_get_access_token_invalid_response(self) -> None:
+        """
+        Test authenticating to get an access-token: Invalid response from Hydra
+        """
+        mock_hydra_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_hydra_response = unittest.mock.MagicMock(requests.Response)
+        mock_hydra_response.status_code = http.HTTPStatus.OK.value
+        mock_hydra_response.json.return_value = {}
+        mock_hydra_api_client.post.return_value = mock_hydra_response
+
+        test_oauth_client = registration.OAuthApiClient(
+            api_client=mock_hydra_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_oauth_client.get_access_token(
+                username="test-username",
+                password="test-password",
+            )
+        self.assertEqual(str(err.exception), "Invalid Hydra response")
+
+        mock_hydra_api_client.post.assert_called_once()
+
+
+class TestPixieRegistrationApiClient(unittest.TestCase):
+    """
+    Test `PixieRegistrationApiClient`
+    """
+
+    @unittest.mock.patch.object(
+        # NOTE: We use `unittest.mock.patch.object()` because a the mock module has a bug that
+        # does not allow us to patch a staticmethod (and also doesn't allow `autospec=True`)
+        #
+        # https://bugs.python.org/issue23078
+        #
+        registration.ApiRequestHelper,
+        "factory_by_known_api_name_from_env",
+    )
+    def test_factory_from_env(self, mock_api_request_helper_factory) -> None:
+        """
+        Test instantiating from the environment
+        """
+        # get a reference before mocking, so we can call the original function we want to test
+        test_factory = registration.PixieRegistrationApiClient.factory_from_env
+
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_pixie_client = unittest.mock.MagicMock(
+            registration.PixieRegistrationApiClient
+        )
+        with unittest.mock.patch(
+            "self_hosted_registration.registration.PixieRegistrationApiClient",
+            autospec=True,
+        ) as mock_constructor:
+            mock_api_request_helper_factory.return_value = mock_api_client
+            mock_constructor.return_value = mock_pixie_client
+
+            pixie_client = test_factory(env_variables_prefix="TEST_")
+            self.assertIs(pixie_client, mock_pixie_client)
+
+            mock_constructor.assert_called_once_with(api_client=mock_api_client)
+
+        mock_api_request_helper_factory.assert_called_once_with(
+            api_name=registration.KnownApiName.PIXIE,
+            env_variables_prefix="TEST_",
+        )
+
+    def test_api_request_without_login(self) -> None:
+        """
+        Test performing an API call (create_api_key) without a prior login
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_pixie_client.create_api_key()
+        self.assertEqual(str(err.exception), "Missing Pixie API login")
+
+        mock_api_client.post.assert_not_called()
+
+    def test_login(self) -> None:
+        """
+        Test login
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.status_code = http.HTTPStatus.OK.value
+        mock_response.json.return_value = {
+            "token": "test-token",
+            "userInfo": {
+                "userID": "test-user-id",
+                "email": "test-email",
+            },
+            "orgInfo": {
+                "orgID": "test-org-id",
+                "orgName": "test-org-name",
+            },
+        }
+        mock_api_client.post.side_effect = [
+            mock_response,
+            Exception("Expected-create_api_key-error"),
+        ]
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        test_pixie_client.login(access_token="test-access-token")
+
+        # now we test that the retrieved token is used in subsequent calls. This fails just
+        # because we don't fully mock out its logic (as it is tested separately). The important
+        # piece is that the API client is called with the token (see below)
+        with self.assertRaises(Exception) as err:
+            test_pixie_client.create_api_key()
+        self.assertEqual(str(err.exception), "Expected-create_api_key-error")
+
+        mock_api_client.post.assert_has_calls(
+            [
+                unittest.mock.call(
+                    path="/api/auth/login",
+                    json={
+                        "accessToken": "test-access-token",
+                    },
+                ),
+                unittest.mock.call(
+                    path="/api/graphql",
+                    # NOTE: This is the important piece - we propagate the bearer auth token
+                    headers={"authorization": "bearer test-token"},
+                    json=unittest.mock.ANY,
+                ),
+            ]
+        )
+
+    def test_login_missing_data(self) -> None:
+        """
+        Test login: invalid response from API
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.status_code = http.HTTPStatus.OK.value
+        mock_response.json.return_value = {}
+        mock_api_client.post.return_value = mock_response
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_pixie_client.login(access_token="test-access-token")
+        self.assertEqual(str(err.exception), "Pixie login did not return expected data")
+
+        mock_api_client.post.assert_called_once_with(
+            path="/api/auth/login",
+            json={
+                "accessToken": "test-access-token",
+            },
+        )
+        mock_response.json.assert_called_once()
+
+    def test_signup(self) -> None:
+        """
+        Test signup
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        mock_signup_response = unittest.mock.MagicMock(requests.Response)
+        mock_signup_response.status_code = http.HTTPStatus.OK.value
+        mock_signup_response.json.return_value = {"token": "test-token"}
+
+        mock_authorized_response = unittest.mock.MagicMock(requests.Response)
+        mock_authorized_response.status_code = http.HTTPStatus.OK.value
+
+        mock_api_client.post.side_effect = [
+            mock_signup_response,
+            mock_authorized_response,
+        ]
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal graphql API invocation as that is tested separately. It
+            # would make this test too complex/do too many things
+            registration.PixieRegistrationApiClient,
+            "_do_graphql_operation",
+        ) as mock_do_graphql_operation:
+            test_pixie_client.signup(
+                org_name="test_org",
+                access_token="test-access-token",
+            )
+            mock_do_graphql_operation.assert_called_once_with(
+                operation_name="CreateOrgFromSetupOrgPage",
+                variables={
+                    "orgName": "test_org",
+                },
+                query=unittest.mock.ANY,
+            )
+
+        mock_api_client.post.assert_has_calls(
+            [
+                unittest.mock.call(
+                    path="/api/auth/signup",
+                    json={
+                        "accessToken": "test-access-token",
+                    },
+                    ignored_error_status=[http.HTTPStatus.INTERNAL_SERVER_ERROR],
+                ),
+                unittest.mock.call(
+                    path="/api/authorized",
+                    headers={"authorization": "bearer test-token"},
+                ),
+            ]
+        )
+
+    def test_signup_missing_data(self) -> None:
+        """
+        Test signup: invalid response from API
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.status_code = http.HTTPStatus.OK.value
+        mock_response.json.return_value = {}
+        mock_api_client.post.return_value = mock_response
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_pixie_client.signup(
+                org_name="test_org",
+                access_token="test-access-token",
+            )
+        self.assertEqual(str(err.exception), "Pixie Org signup did not return token")
+
+        mock_api_client.post.assert_called_once_with(
+            path="/api/auth/signup",
+            json={
+                "accessToken": "test-access-token",
+            },
+            ignored_error_status=[http.HTTPStatus.INTERNAL_SERVER_ERROR],
+        )
+        mock_response.json.assert_called_once()
+
+    def test_signup_api_error(self) -> None:
+        """
+        Test signup: unexpected API error
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.status_code = http.HTTPStatus.INTERNAL_SERVER_ERROR.value
+        mock_response.text = "test error"
+        mock_api_client.post.return_value = mock_response
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_pixie_client.signup(
+                org_name="test_org",
+                access_token="test-access-token",
+            )
+        self.assertEqual(str(err.exception), "Pixie Org signup failed")
+
+        mock_api_client.post.assert_called_once_with(
+            path="/api/auth/signup",
+            json={
+                "accessToken": "test-access-token",
+            },
+            ignored_error_status=[http.HTTPStatus.INTERNAL_SERVER_ERROR],
+        )
+
+    def test_signup_existing_org(self) -> None:
+        """
+        Test signup: Pixie Org exists already
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.status_code = http.HTTPStatus.INTERNAL_SERVER_ERROR.value
+        mock_response.text = "Failed to signup: cannot create duplicate user"
+        mock_api_client.post.return_value = mock_response
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_pixie_client.signup(
+                org_name="test_org",
+                access_token="test-access-token",
+            )
+        self.assertEqual(str(err.exception), "Pixie Org signup failed: Org exists")
+
+        mock_api_client.post.assert_called_once_with(
+            path="/api/auth/signup",
+            json={
+                "accessToken": "test-access-token",
+            },
+            ignored_error_status=[http.HTTPStatus.INTERNAL_SERVER_ERROR],
+        )
+
+    def test_signup_invalid_org_name(self) -> None:
+        """
+        Test signup using an invalid Pixie Org name
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        with self.assertRaises(registration.Error) as err:
+            test_pixie_client.signup(
+                org_name="this is not a valid Pixie Org name",
+                access_token="test-access-token",
+            )
+        self.assertEqual(str(err.exception), "Invalid Pixie Org name")
+
+        mock_api_client.post.assert_not_called()
+
+    def test_create_api_key(self) -> None:
+        """
+        Test create_api_key
+        """
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal API POST invocation to keep complexity of this
+            # test reasonable
+            registration.PixieRegistrationApiClient,
+            "_api_post",
+        ) as mock_api_post:
+            mock_create_response = unittest.mock.MagicMock(requests.Response)
+            mock_create_response.json.return_value = {
+                "data": {
+                    "CreateAPIKey": {
+                        "id": "test-api-key-id",
+                    },
+                },
+            }
+            mock_get_response = unittest.mock.MagicMock(requests.Response)
+            mock_get_response.json.return_value = {
+                "data": {
+                    "apiKey": {
+                        "id": "test-api-key-id",
+                        "key": "test-api-key-secret",
+                        "desc": "",
+                    },
+                },
+            }
+
+            mock_api_post.side_effect = [
+                mock_create_response,
+                mock_get_response,
+            ]
+
+            api_key_id, api_key_secret = test_pixie_client.create_api_key()
+            self.assertEqual(api_key_id, "test-api-key-id")
+            self.assertEqual(api_key_secret, "test-api-key-secret")
+
+            mock_api_post.assert_has_calls(
+                [
+                    unittest.mock.call(
+                        path="/api/graphql",
+                        json={
+                            "operationName": "CreateAPIKeyFromAdminPage",
+                            "variables": {},
+                            "query": unittest.mock.ANY,
+                        },
+                    ),
+                    unittest.mock.call(
+                        path="/api/graphql",
+                        json={
+                            "operationName": "getAPIKey",
+                            "variables": {
+                                "id": "test-api-key-id",
+                            },
+                            "query": unittest.mock.ANY,
+                        },
+                    ),
+                ]
+            )
+
+    def test_create_api_key_missing_create_data(self) -> None:
+        """
+        Test create_api_key: missing data in API call to create key
+        """
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal API POST invocation to keep complexity of this
+            # test reasonable
+            registration.PixieRegistrationApiClient,
+            "_do_graphql_operation",
+        ) as mock_do_graphql_operation:
+            mock_do_graphql_operation.return_value = {
+                "CreateAPIKey": "invalid",
+            }
+
+            with self.assertRaises(registration.ApiError) as err:
+                test_pixie_client.create_api_key()
+            self.assertEqual(
+                str(err.exception),
+                "Response from CreateAPIKeyFromAdminPage is invalid: string indices must "
+                "be integers",
+            )
+
+            mock_do_graphql_operation.assert_called_once_with(
+                operation_name="CreateAPIKeyFromAdminPage",
+                query=unittest.mock.ANY,
+            )
+
+    def test_create_api_key_missing_get_data(self) -> None:
+        """
+        Test create_api_key: missing data in API call to get key
+        """
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal API POST invocation to keep complexity of this
+            # test reasonable
+            registration.PixieRegistrationApiClient,
+            "_do_graphql_operation",
+        ) as mock_do_graphql_operation:
+            mock_do_graphql_operation.side_effect = [
+                {
+                    "CreateAPIKey": {
+                        "id": "test-api-key-id",
+                    },
+                },
+                {
+                    "apiKey": {
+                        "missing": "data",
+                    },
+                },
+            ]
+
+            with self.assertRaises(registration.ApiError) as err:
+                test_pixie_client.create_api_key()
+            self.assertEqual(
+                str(err.exception), "Response from getAPIKey invalid: 'key'"
+            )
+
+            mock_do_graphql_operation.assert_has_calls(
+                [
+                    unittest.mock.call(
+                        operation_name="CreateAPIKeyFromAdminPage",
+                        query=unittest.mock.ANY,
+                    ),
+                    unittest.mock.call(
+                        operation_name="getAPIKey",
+                        variables={
+                            "id": "test-api-key-id",
+                        },
+                        query=unittest.mock.ANY,
+                    ),
+                ]
+            )
+
+    def test_graphql_missing_data(self) -> None:
+        """
+        Test handling of missing data in response to graphql API
+        """
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal API POST invocation to keep complexity of this
+            # test reasonable
+            registration.PixieRegistrationApiClient,
+            "_api_post",
+        ) as mock_api_post:
+            mock_create_response = unittest.mock.MagicMock(requests.Response)
+            mock_create_response.json.return_value = {"test": "incomplete"}
+            mock_api_post.return_value = mock_create_response
+
+            with self.assertRaises(registration.ApiError) as err:
+                test_pixie_client.create_api_key()
+            self.assertEqual(str(err.exception), "GraphQL API response invalid: 'data'")
+
+            mock_api_post.assert_called_once_with(
+                path="/api/graphql",
+                json=unittest.mock.ANY,
+            )
+
+    def test_create_deployment_key(self) -> None:
+        """
+        Test create_deployment_key
+        """
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal helper invocation to keep complexity of this
+            # test reasonable
+            registration.PixieRegistrationApiClient,
+            "_create_id_entity",
+        ) as mock_create_id_entity:
+            mock_create_id_entity.return_value = (
+                "test-deployment-key-id",
+                "test-deployment-key-secret",
+            )
+            api_key_id, api_key_secret = test_pixie_client.create_deployment_key()
+            self.assertEqual(api_key_id, "test-deployment-key-id")
+            self.assertEqual(api_key_secret, "test-deployment-key-secret")
+
+            mock_create_id_entity.assert_called_once_with(
+                entity_type_name="deployment key",
+                create_operation_name="CreateDeploymentKeyFromAdminPage",
+                create_query_name="CreateDeploymentKey",
+                get_operation_name="getDeploymentKey",
+                get_query_name="deploymentKey",
+            )
+
+    def test_configure_org_settings(self) -> None:
+        """
+        Test configure_org_settings
+        """
+        mock_api_client = unittest.mock.MagicMock(registration.ApiRequestHelper)
+        mock_response = unittest.mock.MagicMock(requests.Response)
+        mock_response.status_code = http.HTTPStatus.OK.value
+        mock_response.json.return_value = {
+            "token": "test-token",
+            "userInfo": {
+                "userID": "test-user-id",
+                "email": "test-email",
+            },
+            "orgInfo": {
+                "orgID": "test-org-id",
+                "orgName": "test-org-name",
+            },
+        }
+        mock_api_client.post.return_value = mock_response
+
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=mock_api_client,
+        )
+        test_pixie_client.login(access_token="test-access-token")
+
+        with unittest.mock.patch.object(
+            # we mock out the internal graphql API invocation as that is tested separately. It
+            # would make this test too complex/do too many things
+            registration.PixieRegistrationApiClient,
+            "_do_graphql_operation",
+        ) as mock_do_graphql_operation:
+            test_pixie_client.configure_org_settings(enable_user_approvals=True)
+
+            mock_do_graphql_operation.assert_called_once_with(
+                operation_name="UpdateOrgApprovalSetting",
+                variables={
+                    "orgID": "test-org-id",
+                    "enableApprovals": True,
+                },
+                query=unittest.mock.ANY,
+            )
+
+    def test_configure_user_settings(self) -> None:
+        """
+        Test configure_user_settings
+        """
+        test_pixie_client = registration.PixieRegistrationApiClient(
+            api_client=unittest.mock.MagicMock(registration.ApiRequestHelper),
+        )
+        with unittest.mock.patch.object(
+            # we mock out the internal helper invocation to keep complexity of this
+            # test reasonable
+            registration.PixieRegistrationApiClient,
+            "_do_graphql_operation",
+        ) as mock_do_graphql_operation:
+            test_pixie_client.configure_user_settings(
+                enable_analytics=True,
+            )
+
+            mock_do_graphql_operation.assert_called_once_with(
+                operation_name="UpdateUserAnalyticOptOut",
+                variables={
+                    "analyticsOptout": False,
+                },
+                query=unittest.mock.ANY,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: Running a Pixie cloud/control-plane/backend allows hosting multiple tenants as separate Pixie Orgs. So far, the documentation only mentions a single "default Org" and details of creating additional orgs was not automated. This commit adds a CLI and python module that allows automating tenant/Pixie Org signup.

The CLI exclusively uses the provided python modules. The python modules, in turn, leverage only HTTPS APIs that existed in the Pixie cloud already (Pixie and Kratos/Hydra APIs). Some of the APIs are not exposed, meaning that code needs to be run within the Pixie cloud (or by exposing services securely).

Testing done:
- Deploy Pixie self-hosted cloud
- Deploy multiple Pixie Orgs using the automation (CLI)
- Deploy Vizier sensor using deployment-key generated by the automation for an Org created by the same automation.
- Unit-testing: 100% code-coverage

Relevant Issues: TBD (if the Pixie authors decide that this is worth an upsteam commit).

Type of change: New helper script

Signed-off-by: Clemens Kolbitsch <ckolbitsch@vmware.com>

Fixes pixie-io/pixie#780